### PR TITLE
Add code to restart tasks

### DIFF
--- a/nft_ingester/src/backfiller.rs
+++ b/nft_ingester/src/backfiller.rs
@@ -58,11 +58,11 @@ pub async fn backfiller<T: Messenger>(
             match result {
                 Ok(_) => break,
                 Err(err) if err.is_panic() => {
-                    statsd_count!("ingester.backfiller.panic", 1);
+                    statsd_count!("ingester.backfiller.task_panic", 1);
                 }
                 Err(err) => {
                     let err = err.to_string();
-                    statsd_count!("ingester.backfiller.error", 1, "error" => &err);
+                    statsd_count!("ingester.backfiller.task_error", 1, "error" => &err);
                 }
             }
         }

--- a/nft_ingester/src/backfiller.rs
+++ b/nft_ingester/src/backfiller.rs
@@ -1,6 +1,10 @@
 //! Backfiller that fills gaps in trees by detecting gaps in sequence numbers
 //! in the `backfill_items` table.  Inspired by backfiller.ts/backfill.ts.
-use crate::{error::IngesterError, IngesterConfig, DATABASE_LISTENER_CHANNEL_KEY, RPC_COMMITMENT_KEY, RPC_URL_KEY, safe_metric};
+use crate::{
+    error::IngesterError, safe_metric, IngesterConfig, DATABASE_LISTENER_CHANNEL_KEY,
+    RPC_COMMITMENT_KEY, RPC_URL_KEY,
+};
+use cadence_macros::statsd_count;
 use chrono::Utc;
 use digital_asset_types::dao::backfill_items;
 use flatbuffers::FlatBufferBuilder;
@@ -24,7 +28,6 @@ use solana_transaction_status::{
 };
 use sqlx::{self, postgres::PgListener, Pool, Postgres};
 use std::str::FromStr;
-use cadence_macros::statsd_count;
 use tokio::time::{sleep, Duration};
 
 // Constants used for varying delays when failures occur.
@@ -40,10 +43,29 @@ pub async fn backfiller<T: Messenger>(
     config: IngesterConfig,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        println!("Backfiller task running");
+        loop {
+            let pool_cloned = pool.clone();
+            let config_cloned = config.clone();
 
-        let mut backfiller = Backfiller::<T>::new(pool, config).await;
-        backfiller.run().await;
+            let result = tokio::spawn(async {
+                println!("Backfiller task running");
+
+                let mut backfiller = Backfiller::<T>::new(pool_cloned, config_cloned).await;
+                backfiller.run().await;
+            })
+            .await;
+
+            match result {
+                Ok(_) => break,
+                Err(err) if err.is_panic() => {
+                    statsd_count!("ingester.backfiller.panic", 1);
+                }
+                Err(err) => {
+                    let err = err.to_string();
+                    statsd_count!("ingester.backfiller.error", 1, "error" => &err);
+                }
+            }
+        }
     })
 }
 

--- a/nft_ingester/src/main.rs
+++ b/nft_ingester/src/main.rs
@@ -193,11 +193,11 @@ async fn service_transaction_stream<T: Messenger>(
             match result {
                 Ok(_) => break,
                 Err(err) if err.is_panic() => {
-                    statsd_count!("ingester.service_transaction_stream.panic", 1);
+                    statsd_count!("ingester.service_transaction_stream.task_panic", 1);
                 }
                 Err(err) => {
                     let err = err.to_string();
-                    statsd_count!("ingester.service_transaction_stream.error", 1, "error" => &err);
+                    statsd_count!("ingester.service_transaction_stream.task_error", 1, "error" => &err);
                 }
             }
         }
@@ -241,11 +241,11 @@ async fn service_account_stream<T: Messenger>(
             match result {
                 Ok(_) => break,
                 Err(err) if err.is_panic() => {
-                    statsd_count!("ingester.service_account_stream.panic", 1);
+                    statsd_count!("ingester.service_account_stream.task_panic", 1);
                 }
                 Err(err) => {
                     let err = err.to_string();
-                    statsd_count!("ingester.service_account_stream.error", 1, "error" => &err);
+                    statsd_count!("ingester.service_account_stream.task_error", 1, "error" => &err);
                 }
             }
         }

--- a/nft_ingester/src/main.rs
+++ b/nft_ingester/src/main.rs
@@ -192,8 +192,13 @@ async fn service_transaction_stream<T: Messenger>(
 
             match result {
                 Ok(_) => break,
-                Err(err) if err.is_panic() => (),
-                Err(err) => (),
+                Err(err) if err.is_panic() => {
+                    statsd_count!("ingester.service_transaction_stream.panic", 1);
+                }
+                Err(err) => {
+                    let err = err.to_string();
+                    statsd_count!("ingester.service_transaction_stream.error", 1, "error" => &err);
+                }
             }
         }
     })
@@ -235,8 +240,13 @@ async fn service_account_stream<T: Messenger>(
 
             match result {
                 Ok(_) => break,
-                Err(err) if err.is_panic() => (),
-                Err(err) => (),
+                Err(err) if err.is_panic() => {
+                    statsd_count!("ingester.service_account_stream.panic", 1);
+                }
+                Err(err) => {
+                    let err = err.to_string();
+                    statsd_count!("ingester.service_account_stream.error", 1, "error" => &err);
+                }
             }
         }
     })

--- a/nft_ingester/src/main.rs
+++ b/nft_ingester/src/main.rs
@@ -164,13 +164,13 @@ async fn service_transaction_stream<T: Messenger>(
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         loop {
-            let pool_clone = pool.clone();
-            let tasks_clone = tasks.clone();
-            let messenger_config_clone = messenger_config.clone();
+            let pool_cloned = pool.clone();
+            let tasks_cloned = tasks.clone();
+            let messenger_config_cloned = messenger_config.clone();
 
             let result = tokio::spawn(async {
-                let manager = ProgramTransformer::new(pool_clone, tasks_clone);
-                let mut messenger = T::new(messenger_config_clone).await.unwrap();
+                let manager = ProgramTransformer::new(pool_cloned, tasks_cloned);
+                let mut messenger = T::new(messenger_config_cloned).await.unwrap();
                 println!("Setting up transaction listener");
 
                 let mut ids = Vec::new();
@@ -211,13 +211,13 @@ async fn service_account_stream<T: Messenger>(
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         loop {
-            let pool_clone = pool.clone();
-            let tasks_clone = tasks.clone();
-            let messenger_config_clone = messenger_config.clone();
+            let pool_cloned = pool.clone();
+            let tasks_cloned = tasks.clone();
+            let messenger_config_cloned = messenger_config.clone();
 
             let result = tokio::spawn(async {
-                let manager = ProgramTransformer::new(pool_clone, tasks_clone);
-                let mut messenger = T::new(messenger_config_clone).await.unwrap();
+                let manager = ProgramTransformer::new(pool_cloned, tasks_cloned);
+                let mut messenger = T::new(messenger_config_cloned).await.unwrap();
                 println!("Setting up account listener");
 
                 let mut ids = Vec::new();


### PR DESCRIPTION
### Notes
* Add code to restart account and transaction tasks if they fail.
* Add code to restart backfiller if it fails.
* Add code to allow background task to recover from panics.
* Add metrics.

### Testing
* I instrumented BOTH `service_account_stream` and  `service_transaction_stream` to panic and observed with this new code that it restarts both tasks.
* I instrumented the backfiller to panic and observed with this new code that it restarts the task.
* I instrumented a panic in a background task and observed that with this new code the panic is caught and the overall task manager does not crash.

### Other ideas
* On background task I tried using various versions of `catch_unwind` but they resulted in:
```
`dyn futures_util::Future<Output = Result<(), IngesterError>> + std::marker::Send` may not be safely transferred across an unwind boundary
```
* I tried making a `TaskManager` for account updates and transactions, where I could send `service_account_stream` and `service_transaction_stream` and the `TaskManager` would handle restarting them if they failed.  But started to run into trouble since they are async, such as:
```
the trait `Sync` is not implemented for `dyn FnOnce(Pool<sqlx::Postgres>, UnboundedSender<std::boxed::Box<(dyn BgTask + 'static)>>, MessengerConfig) -> tokio::task::JoinHandle<()>`
```
I'm sure some kind of task manager could be made for that, but it will take more work and I just backed off on that idea for now.