### PR TITLE
Add retries to background task manager

### DIFF
--- a/metaplex-rpc-proxy/Cargo.lock
+++ b/metaplex-rpc-proxy/Cargo.lock
@@ -42,7 +42,7 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -89,6 +89,7 @@ dependencies = [
  "log",
  "proxy-wasm",
  "regex",
+ "wasi 0.7.0",
  "wasm-bindgen",
 ]
 
@@ -165,6 +166,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 
 [[package]]
 name = "wasi"

--- a/nft_ingester/src/tasks/mod.rs
+++ b/nft_ingester/src/tasks/mod.rs
@@ -4,10 +4,9 @@ use cadence_macros::statsd_count;
 use sea_orm::{DatabaseConnection, SqlxPostgresConnector};
 use sqlx::{Pool, Postgres};
 use std::fmt::Display;
-use tokio::{
-    runtime::{Builder, Runtime},
-    sync::mpsc::{self, UnboundedSender},
-};
+use tokio::sync::mpsc::{self, UnboundedSender};
+
+const NUM_TRIES: i32 = 5;
 
 #[async_trait]
 pub trait BgTask: Send + Sync + Display {
@@ -20,28 +19,33 @@ pub struct TaskManager {
 }
 
 impl TaskManager {
-    pub fn new(name: String, pool: Pool<Postgres>) -> Result<Self, IngesterError> {
+    pub fn new(_name: String, pool: Pool<Postgres>) -> Result<Self, IngesterError> {
         let (producer, mut receiver) = mpsc::unbounded_channel::<Box<dyn BgTask>>();
 
         tokio::spawn(async move {
             while let Some(data) = receiver.recv().await {
                 let pool_cloned = pool.clone();
                 let db = SqlxPostgresConnector::from_sqlx_postgres_pool(pool_cloned);
-                let data_name = data.name().to_string();
                 // Spawning another task which allows us to catch panics.
-                let task_res = tokio::spawn(async move { data.task(&db).await }).await;
+                let task_res = tokio::spawn(async move {
+                    for tries in 1..=NUM_TRIES {
+                        match data.task(&db).await {
+                            Ok(_) => {
+                                statsd_count!("ingester.bgtask.complete", 1, "type" => data.name());
+                                println!("{} completed, attempt {}", data, tries);
+                                break;
+                            }
+                            Err(err) => {
+                                statsd_count!("ingester.bgtask.error", 1, "type" => data.name());
+                                println!("{} errored, attempt {}, with {:?}", data, tries, err);
+                            }
+                        }
+                    }
+                })
+                .await;
 
                 match task_res {
-                    Ok(inner_result) => match inner_result {
-                        Ok(_) => {
-                            statsd_count!("ingester.bgtask.complete", 1, "type" => &data_name);
-                            println!("{} completed", data_name)
-                        }
-                        Err(err) => {
-                            statsd_count!("ingester.bgtask.error", 1, "type" => &data_name);
-                            println!("{} errored with {:?}", data_name, err)
-                        }
-                    },
+                    Ok(_) => (),
                     Err(err) if err.is_panic() => {
                         statsd_count!("ingester.bgtask.task_panic", 1);
                     }


### PR DESCRIPTION
## Testing
Instrumented the `DownloadMetadata` task to fail, and observed the background task manager try 5 times then move on.
