### PR TITLE
Use BTreeMap in `get_asset_list_data` to preserve order

### DIFF
--- a/digital_asset_types/src/dapi/asset.rs
+++ b/digital_asset_types/src/dapi/asset.rs
@@ -16,7 +16,7 @@ use mime_guess::Mime;
 use sea_orm::DatabaseConnection;
 use sea_orm::{entity::*, query::*, DbErr};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 use url::Url;
 
@@ -329,7 +329,8 @@ pub async fn get_asset_list_data(
     assets: Vec<(asset::Model, Option<asset_data::Model>)>,
 ) -> Result<Vec<RpcAsset>, DbErr> {
     let mut ids = Vec::with_capacity(assets.len());
-    let mut assets_map = assets.into_iter().fold(HashMap::new(), |mut x, asset| {
+    // Using BTreeMap to preserve order.
+    let mut assets_map = assets.into_iter().fold(BTreeMap::new(), |mut x, asset| {
         if let Some(ad) = asset.1 {
             let id = asset.0.id.clone();
             let fa = FullAsset {


### PR DESCRIPTION
Fixes issue where API calls such as `get_assets_by_owner()` return assets in a different order each time.  The BTreeMap structure preserves key order at the expense of access time:

get | insert | remove | range | append
-- | -- | -- | -- | --
HashMap | O(1)~ | O(1)~* | O(1)~ | N/A | N/A
BTreeMap | O(log(n)) | O(log(n)) | O(log(n)) | O(log(n)) | O(n+m)

See https://doc.rust-lang.org/std/collections/index.html for more interesting info.

Computer science review: O(log(n)) means that as n increases exponentially, running time increases linearly:
n = 16: log2(16) = 4
n = 1KiB: log2(1024) = 10
n = 1 MiB: log2(1048576) = 20
n = really big: log2(1000000000000000000) = 59.794705707973

I don't think in practice this change would have any noticeable affect on our read API's performance.