### PR TITLE
feat: expose more fields to fix decompress using asset from api call

### DIFF
--- a/das_api/Cargo.lock
+++ b/das_api/Cargo.lock
@@ -484,7 +484,7 @@ dependencies = [
  "borsh",
  "flatbuffers",
  "lazy_static",
- "mpl-bubblegum",
+ "mpl-bubblegum 0.1.3",
  "mpl-candy-guard",
  "mpl-candy-machine-core",
  "mpl-token-metadata",
@@ -1004,7 +1004,7 @@ dependencies = [
  "futures",
  "jsonpath_lib",
  "mime_guess",
- "mpl-bubblegum",
+ "mpl-bubblegum 0.3.0",
  "num-derive",
  "num-traits",
  "reqwest",
@@ -2104,6 +2104,21 @@ name = "mpl-bubblegum"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43bff280714053dfa997cab92432d66515145f6840577ab3d7a8d18f14f04bb2"
+dependencies = [
+ "anchor-lang",
+ "bytemuck",
+ "mpl-token-metadata",
+ "solana-program",
+ "spl-account-compression",
+ "spl-associated-token-account",
+ "spl-token",
+]
+
+[[package]]
+name = "mpl-bubblegum"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e283f25eb1f7cb949cbece4d847443bbe7c19eb8f60a0b2e459539b831ec1a"
 dependencies = [
  "anchor-lang",
  "bytemuck",

--- a/digital_asset_types/Cargo.lock
+++ b/digital_asset_types/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
  "borsh",
  "flatbuffers",
  "lazy_static",
- "mpl-bubblegum",
+ "mpl-bubblegum 0.1.3",
  "mpl-candy-guard",
  "mpl-candy-machine-core",
  "mpl-token-metadata",
@@ -1095,7 +1095,7 @@ dependencies = [
  "futures",
  "jsonpath_lib",
  "mime_guess",
- "mpl-bubblegum",
+ "mpl-bubblegum 0.3.0",
  "num-derive",
  "num-traits",
  "reqwest",
@@ -2069,6 +2069,21 @@ name = "mpl-bubblegum"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43bff280714053dfa997cab92432d66515145f6840577ab3d7a8d18f14f04bb2"
+dependencies = [
+ "anchor-lang",
+ "bytemuck",
+ "mpl-token-metadata",
+ "solana-program",
+ "spl-account-compression",
+ "spl-associated-token-account",
+ "spl-token",
+]
+
+[[package]]
+name = "mpl-bubblegum"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e283f25eb1f7cb949cbece4d847443bbe7c19eb8f60a0b2e459539b831ec1a"
 dependencies = [
  "anchor-lang",
  "bytemuck",

--- a/digital_asset_types/Cargo.toml
+++ b/digital_asset_types/Cargo.toml
@@ -29,7 +29,7 @@ mime_guess = "2.0.4"
 url = "2.2.2"
 futures = "0.3.21"
 tokio-test = { version = "0.4.2" }
-mpl-bubblegum = "0.1.3"
+mpl-bubblegum = "0.3.0"
 reqwest = "0.11.11"
 
 [dev-dependencies]

--- a/digital_asset_types/src/dao/mod.rs
+++ b/digital_asset_types/src/dao/mod.rs
@@ -1,5 +1,5 @@
-mod full_asset;
-mod generated;
+pub mod full_asset;
+pub mod generated;
 
 pub use generated::*;
 pub use full_asset::*;

--- a/digital_asset_types/src/rpc/asset.rs
+++ b/digital_asset_types/src/rpc/asset.rs
@@ -1,11 +1,9 @@
 #[cfg(feature = "sql_types")]
-use crate::dao::sea_orm_active_enums::{ChainMutability, Mutability, OwnerType, RoyaltyTargetType};
-use std::str::FromStr;
+use crate::dao::generated::sea_orm_active_enums::{OwnerType, RoyaltyTargetType};
 use {
     serde::{Deserialize, Serialize},
     std::collections::HashMap,
 };
-use crate::dao::asset::Model as AssetModel;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct AssetProof {
@@ -84,7 +82,10 @@ const SCHEMA: &str = "$$schema";
 impl MetadataItem {
     pub fn new(schema: &str) -> Self {
         let mut g = HashMap::new();
-        g.insert(SCHEMA.to_string(), serde_json::Value::String(schema.to_string()));
+        g.insert(
+            SCHEMA.to_string(),
+            serde_json::Value::String(schema.to_string()),
+        );
         Self(g)
     }
 
@@ -155,7 +156,6 @@ pub struct Compression {
     pub creator_hash: String,
     pub asset_hash: String,
 }
-
 
 pub type GroupKey = String;
 pub type GroupValue = String;
@@ -274,7 +274,6 @@ impl From<String> for UseMethod {
     }
 }
 
-
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Uses {
     pub use_method: UseMethod,
@@ -282,6 +281,37 @@ pub struct Uses {
     pub total: u64,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub enum TokenStandard {
+    NonFungible,
+    FungibleAsset,
+    Fungible,
+    NonFungibleEdition,
+}
+
+impl From<String> for TokenStandard {
+    fn from(s: String) -> Self {
+        match &*s {
+            "NonFungible" => TokenStandard::NonFungible,
+            "FungibleAsset" => TokenStandard::FungibleAsset,
+            "Fungible" => TokenStandard::Fungible,
+            "NonFungibleEdition" => TokenStandard::NonFungibleEdition,
+            _ => TokenStandard::NonFungible,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct AdditionalMetadataArgs {
+    pub is_mutable: bool,
+    pub metadata_uri: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub edition_nonce: Option<u64>,
+    pub primary_sale_happened: bool,
+    pub token_standard: TokenStandard,
+    pub name: String,
+    pub symbol: String,
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Asset {
@@ -302,4 +332,5 @@ pub struct Asset {
     pub ownership: Ownership,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uses: Option<Uses>,
+    pub additional_metadata_args: AdditionalMetadataArgs,
 }

--- a/migration/Cargo.lock
+++ b/migration/Cargo.lock
@@ -585,7 +585,7 @@ dependencies = [
  "borsh",
  "flatbuffers",
  "lazy_static",
- "mpl-bubblegum",
+ "mpl-bubblegum 0.1.3",
  "mpl-candy-guard",
  "mpl-candy-machine-core",
  "mpl-token-metadata",
@@ -1184,7 +1184,7 @@ dependencies = [
  "futures",
  "jsonpath_lib",
  "mime_guess",
- "mpl-bubblegum",
+ "mpl-bubblegum 0.3.0",
  "num-derive",
  "num-traits",
  "reqwest",
@@ -2199,6 +2199,21 @@ name = "mpl-bubblegum"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43bff280714053dfa997cab92432d66515145f6840577ab3d7a8d18f14f04bb2"
+dependencies = [
+ "anchor-lang",
+ "bytemuck",
+ "mpl-token-metadata",
+ "solana-program",
+ "spl-account-compression",
+ "spl-associated-token-account",
+ "spl-token",
+]
+
+[[package]]
+name = "mpl-bubblegum"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e283f25eb1f7cb949cbece4d847443bbe7c19eb8f60a0b2e459539b831ec1a"
 dependencies = [
  "anchor-lang",
  "bytemuck",

--- a/nft_ingester/Cargo.lock
+++ b/nft_ingester/Cargo.lock
@@ -538,7 +538,7 @@ dependencies = [
  "borsh",
  "flatbuffers",
  "lazy_static",
- "mpl-bubblegum",
+ "mpl-bubblegum 0.1.3",
  "mpl-candy-guard",
  "mpl-candy-machine-core",
  "mpl-token-metadata",
@@ -1122,7 +1122,7 @@ dependencies = [
  "futures",
  "jsonpath_lib",
  "mime_guess",
- "mpl-bubblegum",
+ "mpl-bubblegum 0.3.0",
  "num-derive",
  "num-traits",
  "reqwest",
@@ -2232,6 +2232,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mpl-bubblegum"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e283f25eb1f7cb949cbece4d847443bbe7c19eb8f60a0b2e459539b831ec1a"
+dependencies = [
+ "anchor-lang",
+ "bytemuck",
+ "mpl-token-metadata",
+ "solana-program",
+ "spl-account-compression",
+ "spl-associated-token-account",
+ "spl-token",
+]
+
+[[package]]
 name = "mpl-candy-guard"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,7 +2356,7 @@ dependencies = [
  "futures-util",
  "hex",
  "lazy_static",
- "mpl-bubblegum",
+ "mpl-bubblegum 0.1.3",
  "num-integer",
  "num-traits",
  "plerkle_messenger",


### PR DESCRIPTION
we need to return these additional fields so that the wallet providers can use them from api call response to call methods like redeem -> decompress correctly since they likely will not have access to original `MetadataArgs`
