### PR TITLE
Removing indeces from missing backfiller column in init.sql

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -55,8 +55,6 @@ CREATE INDEX backfill_items_force_chk_idx on backfill_items (force_chk);
 -- @@@@@@
 CREATE INDEX backfill_items_backfilled_idx on backfill_items (backfilled);
 -- @@@@@@
-CREATE INDEX backfill_items_failed_idx on backfill_items (failed);
--- @@@@@@
 CREATE INDEX backfill_items_tree_seq_idx on backfill_items (tree, seq);
 -- @@@@@@
 CREATE INDEX backfill_items_tree_slot_idx on backfill_items (tree, slot);
@@ -64,8 +62,6 @@ CREATE INDEX backfill_items_tree_slot_idx on backfill_items (tree, slot);
 CREATE INDEX backfill_items_tree_force_chk_idx on backfill_items (tree, force_chk);
 -- @@@@@@
 CREATE INDEX backfill_items_tree_backfilled_idx on backfill_items (tree, backfilled);
--- @@@@@@
-CREATE INDEX backfill_items_tree_failed_idx on backfill_items (tree, failed);
 -- @@@@@@
 
 CREATE


### PR DESCRIPTION
Removed indeces that will fail because failed column is only created by migration.
This would prevent clean run of migrations when no database exists already.
Removing indeces for now they can be added to the migration later.