### PR TITLE
Support multiple backfiller instances

### DIFF
--- a/digital_asset_types/src/dao/generated/asset.rs
+++ b/digital_asset_types/src/dao/generated/asset.rs
@@ -41,10 +41,10 @@ pub struct Model {
     pub created_at: Option<DateTimeWithTimeZone>,
     pub burnt: bool,
     pub slot_updated: i64,
-    pub collection: Option<Vec<u8>>,
-    pub collection_verified: bool,
     pub data_hash: Option<String>,
     pub creator_hash: Option<String>,
+    pub collection: Option<Vec<u8>>,
+    pub collection_verified: bool,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -72,10 +72,10 @@ pub enum Column {
     CreatedAt,
     Burnt,
     SlotUpdated,
-    Collection,
-    CollectionVerified,
     DataHash,
     CreatorHash,
+    Collection,
+    CollectionVerified,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -126,10 +126,10 @@ impl ColumnTrait for Column {
             Self::CreatedAt => ColumnType::TimestampWithTimeZone.def().null(),
             Self::Burnt => ColumnType::Boolean.def(),
             Self::SlotUpdated => ColumnType::BigInteger.def(),
-            Self::Collection => ColumnType::Binary.def().null(),
-            Self::CollectionVerified => ColumnType::Boolean.def(),
             Self::DataHash => ColumnType::Char(Some(50u32)).def().null(),
             Self::CreatorHash => ColumnType::Char(Some(50u32)).def().null(),
+            Self::Collection => ColumnType::Binary.def().null(),
+            Self::CollectionVerified => ColumnType::Boolean.def(),
         }
     }
 }

--- a/digital_asset_types/src/dao/generated/backfill_items.rs
+++ b/digital_asset_types/src/dao/generated/backfill_items.rs
@@ -21,6 +21,7 @@ pub struct Model {
     pub force_chk: bool,
     pub backfilled: bool,
     pub failed: bool,
+    pub locked: bool,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -32,6 +33,7 @@ pub enum Column {
     ForceChk,
     Backfilled,
     Failed,
+    Locked,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -60,6 +62,7 @@ impl ColumnTrait for Column {
             Self::ForceChk => ColumnType::Boolean.def(),
             Self::Backfilled => ColumnType::Boolean.def(),
             Self::Failed => ColumnType::Boolean.def(),
+            Self::Locked => ColumnType::Boolean.def(),
         }
     }
 }

--- a/digital_asset_types/src/dao/generated/sea_orm_active_enums.rs
+++ b/digital_asset_types/src/dao/generated/sea_orm_active_enums.rs
@@ -4,62 +4,6 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "mutability")]
-pub enum Mutability {
-    #[sea_orm(string_value = "immutable")]
-    Immutable,
-    #[sea_orm(string_value = "mutable")]
-    Mutable,
-    #[sea_orm(string_value = "unknown")]
-    Unknown,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(
-    rs_type = "String",
-    db_type = "Enum",
-    enum_name = "specification_asset_class"
-)]
-pub enum SpecificationAssetClass {
-    #[sea_orm(string_value = "FUNGIBLE_ASSET")]
-    FungibleAsset,
-    #[sea_orm(string_value = "FUNGIBLE_TOKEN")]
-    FungibleToken,
-    #[sea_orm(string_value = "IDENTITY_NFT")]
-    IdentityNft,
-    #[sea_orm(string_value = "NFT")]
-    Nft,
-    #[sea_orm(string_value = "NON_TRANSFERABLE_NFT")]
-    NonTransferableNft,
-    #[sea_orm(string_value = "PRINT")]
-    Print,
-    #[sea_orm(string_value = "PRINTABLE_NFT")]
-    PrintableNft,
-    #[sea_orm(string_value = "TRANSFER_RESTRICTED_NFT")]
-    TransferRestrictedNft,
-    #[sea_orm(string_value = "unknown")]
-    Unknown,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "owner_type")]
-pub enum OwnerType {
-    #[sea_orm(string_value = "single")]
-    Single,
-    #[sea_orm(string_value = "token")]
-    Token,
-    #[sea_orm(string_value = "unknown")]
-    Unknown,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "chain_mutability")]
-pub enum ChainMutability {
-    #[sea_orm(string_value = "immutable")]
-    Immutable,
-    #[sea_orm(string_value = "mutable")]
-    Mutable,
-    #[sea_orm(string_value = "unknown")]
-    Unknown,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
 #[sea_orm(
     rs_type = "String",
     db_type = "Enum",
@@ -118,6 +62,62 @@ pub enum V1AccountAttachments {
     MasterEditionV1,
     #[sea_orm(string_value = "master_edition_v2")]
     MasterEditionV2,
+    #[sea_orm(string_value = "unknown")]
+    Unknown,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "owner_type")]
+pub enum OwnerType {
+    #[sea_orm(string_value = "single")]
+    Single,
+    #[sea_orm(string_value = "token")]
+    Token,
+    #[sea_orm(string_value = "unknown")]
+    Unknown,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "chain_mutability")]
+pub enum ChainMutability {
+    #[sea_orm(string_value = "immutable")]
+    Immutable,
+    #[sea_orm(string_value = "mutable")]
+    Mutable,
+    #[sea_orm(string_value = "unknown")]
+    Unknown,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "mutability")]
+pub enum Mutability {
+    #[sea_orm(string_value = "immutable")]
+    Immutable,
+    #[sea_orm(string_value = "mutable")]
+    Mutable,
+    #[sea_orm(string_value = "unknown")]
+    Unknown,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(
+    rs_type = "String",
+    db_type = "Enum",
+    enum_name = "specification_asset_class"
+)]
+pub enum SpecificationAssetClass {
+    #[sea_orm(string_value = "FUNGIBLE_ASSET")]
+    FungibleAsset,
+    #[sea_orm(string_value = "FUNGIBLE_TOKEN")]
+    FungibleToken,
+    #[sea_orm(string_value = "IDENTITY_NFT")]
+    IdentityNft,
+    #[sea_orm(string_value = "NFT")]
+    Nft,
+    #[sea_orm(string_value = "NON_TRANSFERABLE_NFT")]
+    NonTransferableNft,
+    #[sea_orm(string_value = "PRINT")]
+    Print,
+    #[sea_orm(string_value = "PRINTABLE_NFT")]
+    PrintableNft,
+    #[sea_orm(string_value = "TRANSFER_RESTRICTED_NFT")]
+    TransferRestrictedNft,
     #[sea_orm(string_value = "unknown")]
     Unknown,
 }

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -7,6 +7,7 @@ mod m20221025_182127_remove_creator_error_unique_index;
 mod m20221026_155220_add_bg_tasks;
 mod m20221104_094327_add_backfiller_failed;
 mod m20221114_173041_add_collection_info;
+mod m20221115_165700_add_backfiller_locked;
 
 pub struct Migrator;
 
@@ -21,6 +22,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20221026_155220_add_bg_tasks::Migration),
             Box::new(m20221104_094327_add_backfiller_failed::Migration),
             Box::new(m20221114_173041_add_collection_info::Migration),
+            Box::new(m20221115_165700_add_backfiller_locked::Migration),
         ]
     }
 }

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -8,6 +8,7 @@ mod m20221026_155220_add_bg_tasks;
 mod m20221104_094327_add_backfiller_failed;
 mod m20221114_173041_add_collection_info;
 mod m20221115_165700_add_backfiller_locked;
+mod m20221116_110500_add_backfiller_failed_and_locked_indeces;
 
 pub struct Migrator;
 
@@ -23,6 +24,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20221104_094327_add_backfiller_failed::Migration),
             Box::new(m20221114_173041_add_collection_info::Migration),
             Box::new(m20221115_165700_add_backfiller_locked::Migration),
+            Box::new(m20221116_110500_add_backfiller_failed_and_locked_indeces::Migration),
         ]
     }
 }

--- a/migration/src/m20221115_165700_add_backfiller_locked.rs
+++ b/migration/src/m20221115_165700_add_backfiller_locked.rs
@@ -1,0 +1,37 @@
+use digital_asset_types::dao::backfill_items;
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Replace the sample below with your own migration scripts
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(backfill_items::Entity)
+                    .add_column(
+                        ColumnDef::new(Alias::new("locked"))
+                            .boolean()
+                            .not_null()
+                            .default(false),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Replace the sample below with your own migration scripts
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(backfill_items::Entity)
+                    .drop_column(Alias::new("locked"))
+                    .to_owned(),
+            )
+            .await
+    }
+}

--- a/migration/src/m20221116_110500_add_backfiller_failed_and_locked_indeces.rs
+++ b/migration/src/m20221116_110500_add_backfiller_failed_and_locked_indeces.rs
@@ -1,0 +1,87 @@
+use digital_asset_types::dao::backfill_items;
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_index(
+                Index::create()
+                    .name("backfill_items_failed_idx")
+                    .col(backfill_items::Column::Failed)
+                    .table(backfill_items::Entity)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("backfill_items_tree_failed_idx")
+                    .col(backfill_items::Column::Tree)
+                    .col(backfill_items::Column::Failed)
+                    .table(backfill_items::Entity)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("backfill_items_locked_idx")
+                    .col(backfill_items::Column::Locked)
+                    .table(backfill_items::Entity)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("backfill_items_tree_locked_idx")
+                    .col(backfill_items::Column::Tree)
+                    .col(backfill_items::Column::Locked)
+                    .table(backfill_items::Entity)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                sea_query::Index::drop()
+                    .name("backfill_items_failed_idx")
+                    .table(backfill_items::Entity)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .drop_index(
+                sea_query::Index::drop()
+                    .name("backfill_items_tree_failed_idx")
+                    .table(backfill_items::Entity)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .drop_index(
+                sea_query::Index::drop()
+                    .name("backfill_items_locked_idx")
+                    .table(backfill_items::Entity)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .drop_index(
+                sea_query::Index::drop()
+                    .name("backfill_items_tree_locked_idx")
+                    .table(backfill_items::Entity)
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+}

--- a/nft_ingester/src/backfiller.rs
+++ b/nft_ingester/src/backfiller.rs
@@ -230,8 +230,6 @@ impl<T: Messenger> Backfiller<T> {
                         // listener channel.
                         let _notification = self.listener.recv().await.unwrap();
                     } else {
-                        println!("New trees to backfill: {}", backfill_trees.len());
-
                         // First just check if we can talk to an RPC provider.
                         match self.rpc_client.get_version().await {
                             Ok(version) => println!("RPC client version {version}"),
@@ -278,7 +276,7 @@ impl<T: Messenger> Backfiller<T> {
                                 }
 
                                 if tries == NUM_TRIES {
-                                    if let Err(err) = self.mark_as_failed(tree).await {
+                                    if let Err(err) = self.mark_tree_as_failed(tree).await {
                                         println!("Error marking tree as failed to backfill: {err}");
                                     }
                                 } else {
@@ -320,7 +318,7 @@ impl<T: Messenger> Backfiller<T> {
                     }
                     Err(err) => {
                         println!("Error deleting rows and marking as backfilled: {err}");
-                        if let Err(err) = self.mark_as_failed(tree).await {
+                        if let Err(err) = self.mark_tree_as_failed(tree).await {
                             println!("Error marking tree as failed to backfill: {err}");
                         }
                     }
@@ -329,7 +327,7 @@ impl<T: Messenger> Backfiller<T> {
             None => {
                 // Debug.
                 println!("Unexpected error, tree was in list, but no rows found for {tree_string}");
-                if let Err(err) = self.mark_as_failed(tree).await {
+                if let Err(err) = self.mark_tree_as_failed(tree).await {
                     println!("Error marking tree as failed to backfill: {err}");
                 }
             }
@@ -351,35 +349,101 @@ impl<T: Messenger> Backfiller<T> {
     }
 
     async fn get_trees_to_backfill(&self) -> Result<Vec<BackfillTree>, DbErr> {
-        // Get trees with the `force_chk` flag set.
-        let force_chk_trees = UniqueTree::find_by_statement(Statement::from_sql_and_values(
+        // Start a db transaction.
+        let txn = self.db.begin().await?;
+
+        // Lock the backfill_items table.
+        txn.execute(Statement::from_string(
             DbBackend::Postgres,
-            "SELECT DISTINCT backfill_items.tree FROM backfill_items\n\
-            WHERE backfill_items.force_chk = TRUE AND backfill_items.failed = FALSE",
-            vec![],
+            "LOCK TABLE backfill_items IN ACCESS EXCLUSIVE MODE".to_string(),
         ))
-        .all(&self.db)
         .await?;
 
-        // Convert this Vec of `UniqueTree` to a Vec of `BackfillTree` (which contain extra info).
+        // Get trees with the `force_chk` flag set to true (that have not failed and are not locked).
+        let force_chk_trees = Statement::from_string(
+            DbBackend::Postgres,
+            "SELECT DISTINCT backfill_items.tree FROM backfill_items\n\
+            WHERE backfill_items.force_chk = TRUE\n\
+            AND backfill_items.failed = FALSE\n\
+            AND backfill_items.locked = FALSE"
+                .to_string(),
+        );
+
+        let force_chk_trees: Vec<UniqueTree> = txn.query_all(force_chk_trees).await.map(|qr| {
+            qr.iter()
+                .map(|q| UniqueTree::from_query_result(q, "").unwrap())
+                .collect()
+        })?;
+
+        println!(
+            "Number of force check trees to backfill: {}",
+            force_chk_trees.len()
+        );
+
+        for tree in force_chk_trees.iter() {
+            let stmt = backfill_items::Entity::update_many()
+                .col_expr(backfill_items::Column::Locked, Expr::value(true))
+                .filter(backfill_items::Column::Tree.eq(&*tree.tree))
+                .build(DbBackend::Postgres);
+
+            if let Err(err) = txn.execute(stmt).await {
+                println!(
+                    "Error marking tree {} as locked: {}",
+                    bs58::encode(&tree.tree).into_string(),
+                    err
+                );
+                return Err(err);
+            }
+        }
+
+        // Get trees with multiple rows from `backfill_items` table (that have not failed and are not locked).
+        let multi_row_trees = Statement::from_string(
+            DbBackend::Postgres,
+            "SELECT backfill_items.tree FROM backfill_items\n\
+            WHERE backfill_items.failed = FALSE
+            AND backfill_items.locked = FALSE\n\
+            GROUP BY backfill_items.tree\n\
+            HAVING COUNT(*) > 1"
+                .to_string(),
+        );
+
+        let multi_row_trees: Vec<UniqueTree> = txn.query_all(multi_row_trees).await.map(|qr| {
+            qr.iter()
+                .map(|q| UniqueTree::from_query_result(q, "").unwrap())
+                .collect()
+        })?;
+
+        println!(
+            "Number of multi-row trees to backfill {}",
+            multi_row_trees.len()
+        );
+
+        for tree in multi_row_trees.iter() {
+            let stmt = backfill_items::Entity::update_many()
+                .col_expr(backfill_items::Column::Locked, Expr::value(true))
+                .filter(backfill_items::Column::Tree.eq(&*tree.tree))
+                .build(DbBackend::Postgres);
+
+            if let Err(err) = txn.execute(stmt).await {
+                println!(
+                    "Error marking tree {} as locked: {}",
+                    bs58::encode(&tree.tree).into_string(),
+                    err
+                );
+                return Err(err);
+            }
+        }
+
+        // Close out transaction and relinqish the lock.
+        txn.commit().await?;
+
+        // Convert force check trees Vec of `UniqueTree` to a Vec of `BackfillTree` (which contain extra info).
         let mut trees: Vec<BackfillTree> = force_chk_trees
             .into_iter()
             .map(|tree| BackfillTree::new(tree, true))
             .collect();
 
-        // Get trees with multiple rows from `backfill_items` table.
-        let multi_row_trees = UniqueTree::find_by_statement(Statement::from_sql_and_values(
-            DbBackend::Postgres,
-            "SELECT backfill_items.tree FROM backfill_items\n\
-            WHERE backfill_items.failed = FALSE\n\
-            GROUP BY backfill_items.tree\n\
-            HAVING COUNT(*) > 1",
-            vec![],
-        ))
-        .all(&self.db)
-        .await?;
-
-        // Convert this Vec of `UniqueTree` to a Vec of `BackfillTree` (which contain extra info).
+        // Convert multi-row trees Vec of `UniqueTree` to a Vec of `BackfillTree` (which contain extra info).
         let mut multi_row_trees: Vec<BackfillTree> = multi_row_trees
             .into_iter()
             .map(|tree| BackfillTree::new(tree, false))
@@ -407,14 +471,6 @@ impl<T: Messenger> Backfiller<T> {
         let start_seq_vec = MaxSeqItem::find_by_statement(query).all(&self.db).await?;
 
         Ok(start_seq_vec.last().map(|row| row.seq))
-    }
-
-    async fn clear_force_chk_flag(&self, tree: &[u8]) -> Result<UpdateResult, DbErr> {
-        backfill_items::Entity::update_many()
-            .col_expr(backfill_items::Column::ForceChk, Expr::value(false))
-            .filter(backfill_items::Column::Tree.eq(tree))
-            .exec(&self.db)
-            .await
     }
 
     // Similar to `fetchAndPlugGaps()` in `backfiller.ts`.
@@ -628,14 +684,13 @@ impl<T: Messenger> Backfiller<T> {
         }
 
         // Mark remaining row as backfilled so future backfilling can start above this sequence number.
-        backfill_items::Entity::update_many()
-            .col_expr(backfill_items::Column::Backfilled, Expr::value(true))
-            .filter(backfill_items::Column::Tree.eq(tree))
-            .exec(&self.db)
-            .await?;
+        self.mark_tree_as_backfilled(tree).await?;
 
         // Clear the `force_chk` flag if it was set.
         self.clear_force_chk_flag(tree).await?;
+
+        // Unlock tree.
+        self.unlock_tree(tree).await?;
 
         // Debug.
         let test_items = backfill_items::Entity::find()
@@ -650,10 +705,37 @@ impl<T: Messenger> Backfiller<T> {
         Ok(())
     }
 
-    async fn mark_as_failed(&self, tree: &[u8]) -> Result<(), DbErr> {
-        // Mark all rows for this tree as failed future backfilling can skip this tree.
+    async fn mark_tree_as_backfilled(&self, tree: &[u8]) -> Result<(), DbErr> {
+        backfill_items::Entity::update_many()
+            .col_expr(backfill_items::Column::Backfilled, Expr::value(true))
+            .filter(backfill_items::Column::Tree.eq(tree))
+            .exec(&self.db)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn clear_force_chk_flag(&self, tree: &[u8]) -> Result<UpdateResult, DbErr> {
+        backfill_items::Entity::update_many()
+            .col_expr(backfill_items::Column::ForceChk, Expr::value(false))
+            .filter(backfill_items::Column::Tree.eq(tree))
+            .exec(&self.db)
+            .await
+    }
+
+    async fn mark_tree_as_failed(&self, tree: &[u8]) -> Result<(), DbErr> {
         backfill_items::Entity::update_many()
             .col_expr(backfill_items::Column::Failed, Expr::value(true))
+            .filter(backfill_items::Column::Tree.eq(tree))
+            .exec(&self.db)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn unlock_tree(&self, tree: &[u8]) -> Result<(), DbErr> {
+        backfill_items::Entity::update_many()
+            .col_expr(backfill_items::Column::Locked, Expr::value(false))
             .filter(backfill_items::Column::Tree.eq(tree))
             .exec(&self.db)
             .await?;


### PR DESCRIPTION
### Notes
* Add migration for adding `locked` field to `backfill_items` table.
* Adding generated SeaORM code for `backfill_items` locked column.
* Adding migration to create new `backfill_items` indeces.
* Adding table lock to backfiller.
  * Table lock locks `backfill_items` when getting trees to backfill, and marks these trees as locked before relinquishing the lock.
  * Uses transaction mode  and `ACCESS EXCLUSIVE MODE` lock.

### Testing
* Only did some basic happy-path testing so far.
  * I did validate the locking worked by temporarily adding a delay and then trying to access the table from another process before the delay expired.
  * Basically tested that when a new row is inserted into `backfill_items` table, the backfiller still runs, marks it as backfilled and clears the extra rows as expected, and does not do anything really unexpected such as hold the lock forever.
  * Also please take detailed look at my migrations.  They work but I'm not sure if they are all fully what we would want them to be.
