### PR TITLE
Fix backfilling end_slot calculation bug

### DIFF
--- a/nft_ingester/src/backfiller.rs
+++ b/nft_ingester/src/backfiller.rs
@@ -815,7 +815,7 @@ impl<'a, T: Messenger> Backfiller<'a, T> {
         let diff = gap.curr.slot - gap.prev.slot;
         let mut num_iter = (diff + 250_000) / 500_000;
         let mut start_slot = gap.prev.slot;
-        let mut end_slot = cmp::min(500_000, gap.curr.slot);
+        let mut end_slot = gap.prev.slot + cmp::min(500_000, diff);
         let get_confirmed_slot_tasks = FuturesUnordered::new();
         if num_iter == 0 {
             num_iter = 1;


### PR DESCRIPTION
It looks like there was a bug in how the end_slot was calculated for backfilling. This lead to the backfiller always trying to fill between (curr_slot, 500_000) which would fail (no transactions fetched because usually the slot would be higher).
