### PR TITLE
Adds specific error message for pagination limit

### DIFF
--- a/das_api/src/api/api_impl.rs
+++ b/das_api/src/api/api_impl.rs
@@ -61,7 +61,7 @@ impl DasApi {
         if let Some(limit) = limit {
             // make config item
             if *limit > 1000 {
-                return Err(DasApiError::PaginationError);
+                return Err(DasApiError::PaginationLimitError);
             }
         }
 

--- a/das_api/src/error.rs
+++ b/das_api/src/error.rs
@@ -18,6 +18,9 @@ pub enum DasApiError {
     PaginationError,
     #[error("Pagination Error. No Pagination Method Selected")]
     PaginationEmptyError,
+    // TODO change `1000` to a dynamic parameter provided by a config
+    #[error("Pagination Error. Limit must be less than or equal to 1000.")]
+    PaginationLimitError,
     #[error("Deserialization error: {0}")]
     DeserializationError(#[from] serde_json::Error),
 }


### PR DESCRIPTION
Adds a specific error message when a RPC request specifies a `limit` parameter that's greater than the limit specified in `das_api/src/api/api_impl.rs`.

Closes #35 