### PR TITLE
fix: materialize cl_items to decrease locking

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -20,18 +20,23 @@ CREATE TABLE cl_items
     hash     BYTEA  NOT NULL
 );
 -- @@@@@@
--- Index All the things space is cheap
-CREATE INDEX cl_items_tree_idx on cl_items (tree);
+-- Index All the things space is cheap, but index rebuilds are not
+-- Let's materialize cl_items into a view so the indexes don't lock
+-- the cl_items table and prevent ingest
+CREATE MATERIALIZED VIEW cl_items_view AS
+SELECT * FROM my_table;
+
+CREATE INDEX cl_items_tree_idx on cl_items_view (tree);
 -- @@@@@@
-CREATE INDEX cl_items_hash_idx on cl_items (hash);
+CREATE INDEX cl_items_hash_idx on cl_items_view (hash);
 -- @@@@@@
-CREATE INDEX cl_items_level on cl_items (level);
+CREATE INDEX cl_items_level on cl_items_view (level);
 -- @@@@@@
-CREATE INDEX cl_items_node_idx on cl_items (node_idx);
+CREATE INDEX cl_items_node_idx on cl_items_view (node_idx);
 -- @@@@@@
-CREATE INDEX cl_items_leaf_idx on cl_items (leaf_idx);
+CREATE INDEX cl_items_leaf_idx on cl_items_view (leaf_idx);
 -- @@@@@@
-CREATE UNIQUE INDEX cl_items__tree_node on cl_items (tree, node_idx);
+CREATE UNIQUE INDEX cl_items__tree_node on cl_items_view (tree, node_idx);
 -- @@@@@@
 
 CREATE TABLE backfill_items


### PR DESCRIPTION
Index updates will lock the table, as the size increases index update latency increases O(n) with table size.

Using a materialized view will only lock the view, not the original table, allowing ingest to continue.

This comes at the expense of the view becoming stale, and requiring `REFRESH MATERIALIZED VIEW cl_items_view;` to be executed on a business-level cadence.


Thank you for taking the time to make an enhancement or bug fix to the digital asset validator rpc repo.
To ensure a quality PR experience this call may be recorded. Just Kidding, but we do expect a few things.

1. The Name of the PR will show up in the changelog so make it a good one, we will rename PRs or reject based on the name.
2. Please make the PR as small as possible to achieve the bugfix or feature. Big prs often are scary and hard to review.
3. Be kind to your reviewers 🤓
4. Add a good description, so we can see what the PR is all about without investing the time in the code review. We will often review code at a certain time in the day and having a list if important prs to review helps us move that along.
