### PR TITLE
Add structured logging and reduce log noisiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ count ingester.ingest_error
 time ingester.bgtask.proc_time
 count ingester.bgtask.success
 count ingester.bgtask.error
+count ingester.bgtask.network_error
 time ingester.bgtask.bus_time
 count ingester.bgtask.identical
 

--- a/das_api/Cargo.lock
+++ b/das_api/Cargo.lock
@@ -1068,6 +1068,7 @@ dependencies = [
  "bs58 0.4.0",
  "futures",
  "jsonpath_lib",
+ "log",
  "mime_guess",
  "num-derive",
  "num-traits",

--- a/digital_asset_types/Cargo.lock
+++ b/digital_asset_types/Cargo.lock
@@ -1036,6 +1036,7 @@ dependencies = [
  "bs58 0.4.0",
  "futures",
  "jsonpath_lib",
+ "log",
  "mime_guess",
  "num-derive",
  "num-traits",

--- a/digital_asset_types/Cargo.toml
+++ b/digital_asset_types/Cargo.toml
@@ -32,3 +32,4 @@ async-trait = "0.1.60"
 tokio = { version = "1.22.0", features = ["full"] }
 schemars = "0.8.6"
 schemars_derive = "0.8.6"
+log = "0.4.17"

--- a/migration/Cargo.lock
+++ b/migration/Cargo.lock
@@ -1167,6 +1167,7 @@ dependencies = [
  "bs58 0.4.0",
  "futures",
  "jsonpath_lib",
+ "log",
  "mime_guess",
  "num-derive",
  "num-traits",

--- a/nft_ingester/Cargo.lock
+++ b/nft_ingester/Cargo.lock
@@ -1304,6 +1304,7 @@ dependencies = [
  "bs58 0.4.0",
  "futures",
  "jsonpath_lib",
+ "log",
  "mime_guess",
  "num-derive",
  "num-traits",
@@ -2372,6 +2373,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2655,6 +2665,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-stream",
+ "tracing-subscriber",
  "url",
  "uuid",
 ]
@@ -2679,6 +2690,16 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -2911,6 +2932,12 @@ dependencies = [
  "quote 1.0.26",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -3566,6 +3593,15 @@ checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
  "regex-syntax",
 ]
 
@@ -4252,6 +4288,15 @@ dependencies = [
  "quote 1.0.26",
  "serde",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -5322,6 +5367,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5574,6 +5629,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -5741,6 +5839,12 @@ dependencies = [
  "getrandom 0.2.8",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/nft_ingester/Cargo.toml
+++ b/nft_ingester/Cargo.toml
@@ -52,6 +52,11 @@ anchor-lang = "=0.26.0"
 borsh = "0.9.1"
 stretto = { version = "0.7", features = ["async"] }
 tokio-stream = "0.1.12"
+tracing-subscriber = { version = "0.3.16", features = [
+  "json",
+  "env-filter",
+  "ansi",
+] }
 
 [dependencies.num-integer] 
 version = "0.1.44"

--- a/nft_ingester/src/account_updates.rs
+++ b/nft_ingester/src/account_updates.rs
@@ -41,7 +41,7 @@ pub fn account_worker<T: Messenger>(
                             tasks.spawn(handle_account(Arc::clone(&manager), item));
                         }
                         if len > 0 {
-                            debug!("Processed {} account", len);
+                            debug!("Processed {} accounts", len);
                         }
                     }
                     Err(e) => {

--- a/nft_ingester/src/backfiller.rs
+++ b/nft_ingester/src/backfiller.rs
@@ -459,7 +459,7 @@ impl<'a, T: Messenger> Backfiller<'a, T> {
         cn: &impl ConnectionTrait,
     ) -> Result<Vec<MissingTree>, IngesterError> {
         let mut all_trees: HashMap<Pubkey, SlotSeq> = self.fetch_trees_by_gpa().await?;
-        info!("Number of Trees on Chain {}", all_trees.len());
+        debug!("Number of Trees on Chain {}", all_trees.len());
         let get_locked_or_failed_trees = Statement::from_string(
             DbBackend::Postgres,
             "SELECT DISTINCT tree FROM backfill_items WHERE failed = true\n\
@@ -490,7 +490,11 @@ impl<'a, T: Messenger> Backfiller<'a, T> {
             .into_iter()
             .map(|(k, s)| MissingTree { tree: k, slot: s.0 })
             .collect::<Vec<MissingTree>>();
-        info!("Number of Missing local trees: {}", missing_trees.len());
+        if missing_trees.len() > 0 {
+            info!("Number of Missing local trees: {}", missing_trees.len());
+        } else {
+            debug!("No missing trees");
+        }
         Ok(missing_trees)
     }
 

--- a/nft_ingester/src/config.rs
+++ b/nft_ingester/src/config.rs
@@ -4,6 +4,8 @@ use figment::{providers::Env, value::Value, Figment};
 use plerkle_messenger::MessengerConfig;
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use serde::Deserialize;
+use std::env;
+use tracing_subscriber::fmt;
 
 use crate::error::IngesterError;
 
@@ -111,4 +113,12 @@ pub fn setup_config() -> IngesterConfig {
         .unwrap();
     config.code_version = Some(CODE_VERSION);
     config
+}
+
+pub fn init_logger() {
+    let env_filter = env::var("RUST_LOG")
+        .or::<Result<String, ()>>(Ok("info".to_string()))
+        .unwrap();
+    let t = tracing_subscriber::fmt().with_env_filter(env_filter);
+    t.event_format(fmt::format::json()).init();
 }

--- a/nft_ingester/src/main.rs
+++ b/nft_ingester/src/main.rs
@@ -10,13 +10,11 @@ mod stream;
 pub mod tasks;
 mod transaction_notifications;
 
-use env_logger;
-
 use crate::{
     account_updates::account_worker,
     ack::ack_worker,
     backfiller::setup_backfiller,
-    config::{setup_config, IngesterRole},
+    config::{init_logger, setup_config, IngesterRole},
     database::setup_database,
     error::IngesterError,
     metrics::setup_metrics,
@@ -34,12 +32,12 @@ use plerkle_messenger::{
 };
 use tokio::{
     signal,
-    task::{JoinError, JoinSet},
+    task::{JoinSet},
 };
 
 #[tokio::main(flavor = "multi_thread")]
 pub async fn main() -> Result<(), IngesterError> {
-    env_logger::init();
+    init_logger();
     info!("Starting nft_ingester");
     // Setup Configuration and Metrics ---------------------------------------------
     // Pull Env variables into config struct

--- a/nft_ingester/src/metrics.rs
+++ b/nft_ingester/src/metrics.rs
@@ -86,7 +86,7 @@ pub fn capture_result(
             ret_id = Some(id);
         }
         Err(err) => {
-            println!("Error handling account update: {:?}", err);
+            error!("Error handling account update: {:?}", err);
             metric! {
                 statsd_count!("ingester.ingest_update_error", 1, label.0 => &label.1, "stream" => stream, "error" => "u");
             }

--- a/nft_ingester/src/program_transformers/bubblegum/db.rs
+++ b/nft_ingester/src/program_transformers/bubblegum/db.rs
@@ -1,7 +1,8 @@
 use crate::error::IngesterError;
 use digital_asset_types::dao::{asset, asset_creators, backfill_items, cl_items};
+use log::{info, debug};
 use sea_orm::{
-    entity::*, query::*, sea_query::OnConflict, ColumnTrait, DatabaseTransaction, DbBackend, DbErr,
+    entity::*, query::*, sea_query::OnConflict, ColumnTrait, DbBackend, DbErr,
     EntityTrait,
 };
 use spl_account_compression::events::ChangeLogEventV1;
@@ -36,7 +37,7 @@ where
     let tree_id = change_log_event.id.as_ref();
     for p in change_log_event.path.iter() {
         let node_idx = p.index as i64;
-        println!(
+        debug!(
             "seq {}, index {} level {}, node {:?}",
             change_log_event.seq,
             p.index,
@@ -96,7 +97,7 @@ where
         // sequence number.  So in this case we set at flag to force checking the tree.
         let force_chk = rows.is_empty() && change_log_event.seq > 1;
 
-        println!("Adding to backfill_items table at level {}", i - 1);
+        info!("Adding to backfill_items table at level {}", i - 1);
         let item = backfill_items::ActiveModel {
             tree: Set(tree_id.to_vec()),
             seq: Set(change_log_event.seq as i64),

--- a/nft_ingester/src/program_transformers/bubblegum/mod.rs
+++ b/nft_ingester/src/program_transformers/bubblegum/mod.rs
@@ -3,6 +3,7 @@ use blockbuster::{
     instruction::InstructionBundle,
     programs::bubblegum::{BubblegumInstruction, InstructionName},
 };
+use log::debug;
 use sea_orm::{ConnectionTrait, TransactionTrait};
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -33,52 +34,52 @@ where
     let ix_type = &parsing_result.instruction;
     match ix_type {
         InstructionName::Unknown => {
-            println!("Unknown instruction:");
+            debug!("Unknown instruction:");
         }
         InstructionName::MintV1 => {
-            println!("MintV1 instruction:");
+            debug!("MintV1 instruction:");
         }
         InstructionName::MintToCollectionV1 => {
-            println!("MintToCollectionV1 instruction:");
+            debug!("MintToCollectionV1 instruction:");
         }
         InstructionName::Redeem => {
-            println!("Redeem instruction:");
+            debug!("Redeem instruction:");
         }
         InstructionName::CancelRedeem => {
-            println!("CancelRedeem instruction:");
+            debug!("CancelRedeem instruction:");
         }
         InstructionName::Transfer => {
-            println!("Transfer instruction:");
+            debug!("Transfer instruction:");
         }
         InstructionName::Delegate => {
-            println!("Delegate instruction:");
+            debug!("Delegate instruction:");
         }
         InstructionName::DecompressV1 => {
-            println!("DecompressV1 instruction:");
+            debug!("DecompressV1 instruction:");
         }
         InstructionName::Compress => {
-            println!("Compress instruction:");
+            debug!("Compress instruction:");
         }
         InstructionName::Burn => {
-            println!("Burn instruction:");
+            debug!("Burn instruction:");
         }
         InstructionName::CreateTree => {
-            println!("CreateTree instruction:");
+            debug!("CreateTree instruction:");
         }
         InstructionName::VerifyCreator => {
-            println!("VerifyCreator instruction:");
+            debug!("VerifyCreator instruction:");
         }
         InstructionName::UnverifyCreator => {
-            println!("UnverifyCreator instruction:");
+            debug!("UnverifyCreator instruction:");
         }
         InstructionName::VerifyCollection => {
-            println!("VerifyCollection instruction:");
+            debug!("VerifyCollection instruction:");
         }
         InstructionName::UnverifyCollection => {
-            println!("UnverifyCollection instruction:");
+            debug!("UnverifyCollection instruction:");
         }
         InstructionName::SetAndVerifyCollection => {
-            println!("SetAndVerifyCollection instruction:");
+            debug!("SetAndVerifyCollection instruction:");
         }
     }
 
@@ -121,7 +122,7 @@ where
         InstructionName::SetAndVerifyCollection => {
             collection_verification::process(parsing_result, bundle, txn, true).await?;
         }
-        _ => println!("Bubblegum: Not Implemented Instruction"),
+        _ => debug!("Bubblegum: Not Implemented Instruction"),
     }
     Ok(())
 }

--- a/nft_ingester/src/program_transformers/mod.rs
+++ b/nft_ingester/src/program_transformers/mod.rs
@@ -7,7 +7,7 @@ use blockbuster::{
         token_metadata::TokenMetadataParser, ProgramParseResult,
     },
 };
-use log::{debug, error};
+use log::{debug, error, info};
 use plerkle_serialization::{AccountInfo, Pubkey as FBPubkey, TransactionInfo};
 use sea_orm::{DatabaseConnection, SqlxPostgresConnector, TransactionTrait};
 use solana_sdk::pubkey::Pubkey;
@@ -69,7 +69,7 @@ impl ProgramTransformer {
         &self,
         tx: &'a TransactionInfo<'a>,
     ) -> Result<(), IngesterError> {
-        println!("Handling Transaction: {:?}", tx.signature());
+        info!("Handling Transaction: {:?}", tx.signature());
         let instructions = self.break_transaction(&tx);
         let accounts = tx.account_keys().unwrap_or_default();
         let slot = tx.slot();
@@ -113,7 +113,7 @@ impl ProgramTransformer {
             };
 
             if let Some(program) = self.match_program(&ix.program) {
-                println!("Found a ix for program: {:?}", program.key());
+                debug!("Found a ix for program: {:?}", program.key());
                 let result = program.handle_instruction(&ix)?;
                 let concrete = result.result_type();
                 match concrete {


### PR DESCRIPTION
## Overview
Use structured JSON logging to allow log applications (e.g. CloudWatch) to query by fields (e.g. level). Adjust log levels to reduce overall log noisiness and storage requirements.

Also switched off-chain retrieval errors to separate log and metric. This scenario is expected and polluted metrics/logs, making it harder to detect more serious errors.

## Testing
Deployed e2e in Helius prod devnet and mainnet environments.