### PR TITLE
Fix GetAssetsByCreator query

### DIFF
--- a/das_api/Cargo.lock
+++ b/das_api/Cargo.lock
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "das_api"
-version = "0.6.8"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "bs58 0.4.0",

--- a/das_api/Cargo.toml
+++ b/das_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "das_api"
-version = "0.6.8"
+version = "0.7.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/das_api/src/api/api_impl.rs
+++ b/das_api/src/api/api_impl.rs
@@ -9,8 +9,8 @@ use digital_asset_types::{
         SearchAssetsQuery,
     },
     dapi::{
-        get_asset, get_assets_by_authority, get_assets_by_creators, get_assets_by_group,
-        get_assets_by_owner, get_proof_for_asset, search_assets,
+        get_asset, get_assets_by_authority, get_assets_by_group,
+        get_assets_by_owner, get_proof_for_asset, search_assets, get_assets_by_creator,
     },
     rpc::{filter::SearchConditionType, response::GetGroupingResponse},
     rpc::{OwnershipModel, RoyaltyModel},
@@ -205,9 +205,9 @@ impl ApiContract for DasApi {
         self.validate_pagination(&limit, &page, &before, &after)?;
         let sort_by = sort_by.unwrap_or_default();
         let only_verified = only_verified.unwrap_or_default();
-        get_assets_by_creators(
+        get_assets_by_creator(
             &self.db_connection,
-            vec![creator_address_bytes],
+            creator_address_bytes,
             only_verified,
             sort_by,
             limit.map(|x| x as u64).unwrap_or(1000),

--- a/digital_asset_types/src/dapi/assets_by_creator.rs
+++ b/digital_asset_types/src/dapi/assets_by_creator.rs
@@ -6,9 +6,9 @@ use sea_orm::DbErr;
 
 use super::common::{build_asset_response, create_pagination, create_sorting};
 
-pub async fn get_assets_by_creators(
+pub async fn get_assets_by_creator(
     db: &DatabaseConnection,
-    creators: Vec<Vec<u8>>,
+    creator: Vec<u8>,
     only_verified: bool,
     sorting: AssetSorting,
     limit: u64,
@@ -20,7 +20,7 @@ pub async fn get_assets_by_creators(
     let (sort_direction, sort_column) = create_sorting(sorting);
     let assets = scopes::asset::get_by_creator(
         db,
-        creators,
+        creator,
         only_verified,
         sort_column,
         sort_direction,

--- a/nft_ingester/Cargo.lock
+++ b/nft_ingester/Cargo.lock
@@ -2616,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "nft_ingester"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anchor-lang",
  "async-trait",

--- a/nft_ingester/Cargo.toml
+++ b/nft_ingester/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nft_ingester"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary
* Fixes https://github.com/metaplex-foundation/digital-asset-rpc-infrastructure/issues/51
* The SQL was querying for "creator = X OR supply > 0" instead of "creator = X AND supply >0"
* I removed the multiple creators from the query since we only ever feed a single creator to the method. Simpler code = less likely for bugs.

## Testing
* Tested e2e in the Helius dev environment with mainnet data. Ensured the GetassetsByCreator returns the expected for both cases of `only_verified=true/false`.
