### PR TITLE
Fix before/after cursors by decoding base58 keys.

### DIFF
--- a/das_api/src/api/api_impl.rs
+++ b/das_api/src/api/api_impl.rs
@@ -9,8 +9,8 @@ use digital_asset_types::{
         SearchAssetsQuery,
     },
     dapi::{
-        get_asset, get_assets_by_authority, get_assets_by_group,
-        get_assets_by_owner, get_proof_for_asset, search_assets, get_assets_by_creator,
+        get_asset, get_assets_by_authority, get_assets_by_creator, get_assets_by_group,
+        get_assets_by_owner, get_proof_for_asset, search_assets,
     },
     rpc::{filter::SearchConditionType, response::GetGroupingResponse},
     rpc::{OwnershipModel, RoyaltyModel},
@@ -148,8 +148,8 @@ impl ApiContract for DasApi {
             sort_by,
             limit.map(|x| x as u64).unwrap_or(1000),
             page.map(|x| x as u64),
-            before.map(|x| x.as_bytes().to_vec()),
-            after.map(|x| x.as_bytes().to_vec()),
+            before.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
+            after.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
         )
         .await
         .map_err(Into::into)
@@ -179,8 +179,8 @@ impl ApiContract for DasApi {
             sort_by,
             limit.map(|x| x as u64).unwrap_or(1000),
             page.map(|x| x as u64),
-            before.map(|x| x.as_bytes().to_vec()),
-            after.map(|x| x.as_bytes().to_vec()),
+            before.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
+            after.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
         )
         .await
         .map_err(Into::into)
@@ -212,8 +212,8 @@ impl ApiContract for DasApi {
             sort_by,
             limit.map(|x| x as u64).unwrap_or(1000),
             page.map(|x| x as u64),
-            before.map(|x| x.as_bytes().to_vec()),
-            after.map(|x| x.as_bytes().to_vec()),
+            before.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
+            after.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
         )
         .await
         .map_err(Into::into)
@@ -242,8 +242,8 @@ impl ApiContract for DasApi {
             sort_by,
             limit.map(|x| x as u64).unwrap_or(1000),
             page.map(|x| x as u64),
-            before.map(|x| x.as_bytes().to_vec()),
-            after.map(|x| x.as_bytes().to_vec()),
+            before.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
+            after.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
         )
         .await
         .map_err(Into::into)
@@ -333,8 +333,8 @@ impl ApiContract for DasApi {
             sort_by,
             limit.map(|x| x as u64).unwrap_or(1000),
             page.map(|x| x as u64),
-            before.map(|x| x.as_bytes().to_vec()),
-            after.map(|x| x.as_bytes().to_vec()),
+            before.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
+            after.map(|x| bs58::decode(x).into_vec().unwrap_or_default()),
         )
         .await
         .map_err(Into::into)


### PR DESCRIPTION
Before/after strings for pagination are validated as base58 strings.

However, when we decode them into Vec<u8s> we use `as_bytes()` which uses ascii values.

Instead we need to bs58::decode them.