### PR TITLE
fix(das-api): fix getAssetProof

### DIFF
--- a/digital_asset_types/src/dapi/change_logs.rs
+++ b/digital_asset_types/src/dapi/change_logs.rs
@@ -1,6 +1,6 @@
+use log::debug;
 use sea_orm::sea_query::Expr;
 use sea_orm::{DatabaseConnection, DbBackend};
-use log::debug;
 use {
     crate::dao::asset,
     crate::dao::cl_items,
@@ -66,16 +66,14 @@ pub async fn get_proof_for_asset(
             .map(|q| SimpleChangeLog::from_query_result(q, "").unwrap())
             .collect()
     })?;
-    if nodes.len() != expected_proof_size {
-        for node in nodes.iter() {
-            if node.level < final_node_list.len().try_into().unwrap() {
-                final_node_list[node.level as usize] = node.to_owned();
-            }
+    for node in nodes.iter() {
+        if node.level < final_node_list.len().try_into().unwrap() {
+            final_node_list[node.level as usize] = node.to_owned();
         }
-        for (i, (n, nin)) in final_node_list.iter_mut().zip(req_indexes).enumerate() {
-            if *n == SimpleChangeLog::default() {
-                *n = make_empty_node(i as i64, nin);
-            }
+    }
+    for (i, (n, nin)) in final_node_list.iter_mut().zip(req_indexes).enumerate() {
+        if *n == SimpleChangeLog::default() {
+            *n = make_empty_node(i as i64, nin);
         }
     }
     for n in final_node_list.iter() {


### PR DESCRIPTION
Empty proofs were being provided once we reached the 50% of the tree size. 