### PR TITLE
Fix collection verification and change to use upserts to support out of order processing

### DIFF
--- a/das_api/src/api/api_impl.rs
+++ b/das_api/src/api/api_impl.rs
@@ -1,5 +1,3 @@
-use std::vec;
-
 use digital_asset_types::{
     dao::{
         scopes::asset::get_grouping,
@@ -356,7 +354,7 @@ impl ApiContract for DasApi {
         } = payload;
         let gs = get_grouping(&self.db_connection, group_key.clone(), group_value.clone()).await?;
         Ok(GetGroupingResponse {
-            group_key: group_key,
+            group_key,
             group_name: group_value,
             group_size: gs.size,
         })

--- a/das_api/src/api/mod.rs
+++ b/das_api/src/api/mod.rs
@@ -1,4 +1,4 @@
-use crate::{DasApiError, RpcModule};
+use crate::DasApiError;
 use async_trait::async_trait;
 use digital_asset_types::rpc::filter::SearchConditionType;
 use digital_asset_types::rpc::response::AssetList;

--- a/das_api/src/main.rs
+++ b/das_api/src/main.rs
@@ -4,7 +4,7 @@ mod config;
 mod error;
 mod validation;
 
-use std::time::{Duration, Instant};
+use std::time::Instant;
 use {
     crate::api::DasApi,
     crate::builder::RpcApiBuilder,
@@ -17,7 +17,7 @@ use {
     std::net::UdpSocket,
 };
 
-use hyper::{http, Method};
+use hyper::Method;
 use log::{debug, info};
 use tower_http::cors::{Any, CorsLayer};
 

--- a/digital_asset_types/src/dao/generated/asset.rs
+++ b/digital_asset_types/src/dao/generated/asset.rs
@@ -97,8 +97,8 @@ pub enum Relation {
     AssetData,
     AssetV1AccountAttachments,
     AssetCreators,
-    AssetGrouping,
     AssetAuthority,
+    AssetGrouping,
 }
 
 impl ColumnTrait for Column {
@@ -148,8 +148,8 @@ impl RelationTrait for Relation {
                 Entity::has_many(super::asset_v1_account_attachments::Entity).into()
             }
             Self::AssetCreators => Entity::has_many(super::asset_creators::Entity).into(),
-            Self::AssetGrouping => Entity::has_many(super::asset_grouping::Entity).into(),
             Self::AssetAuthority => Entity::has_many(super::asset_authority::Entity).into(),
+            Self::AssetGrouping => Entity::has_many(super::asset_grouping::Entity).into(),
         }
     }
 }
@@ -172,15 +172,15 @@ impl Related<super::asset_creators::Entity> for Entity {
     }
 }
 
-impl Related<super::asset_grouping::Entity> for Entity {
-    fn to() -> RelationDef {
-        Relation::AssetGrouping.def()
-    }
-}
-
 impl Related<super::asset_authority::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::AssetAuthority.def()
+    }
+}
+
+impl Related<super::asset_grouping::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::AssetGrouping.def()
     }
 }
 

--- a/digital_asset_types/src/dao/generated/asset_grouping.rs
+++ b/digital_asset_types/src/dao/generated/asset_grouping.rs
@@ -20,7 +20,7 @@ pub struct Model {
     pub group_value: Option<String>,
     pub seq: Option<i64>,
     pub slot_updated: Option<i64>,
-    pub verified: Option<bool>,
+    pub verified: bool,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -61,7 +61,7 @@ impl ColumnTrait for Column {
             Self::GroupValue => ColumnType::Text.def().null(),
             Self::Seq => ColumnType::BigInteger.def().null(),
             Self::SlotUpdated => ColumnType::BigInteger.def().null(),
-            Self::Verified => ColumnType::Boolean.def().null(),
+            Self::Verified => ColumnType::Boolean.def(),
         }
     }
 }

--- a/digital_asset_types/src/dao/generated/asset_grouping.rs
+++ b/digital_asset_types/src/dao/generated/asset_grouping.rs
@@ -17,9 +17,9 @@ pub struct Model {
     pub id: i64,
     pub asset_id: Vec<u8>,
     pub group_key: String,
-    pub group_value: String,
-    pub seq: i64,
-    pub slot_updated: i64,
+    pub group_value: Option<String>,
+    pub seq: Option<i64>,
+    pub slot_updated: Option<i64>,
     pub verified: Option<bool>,
 }
 
@@ -58,9 +58,9 @@ impl ColumnTrait for Column {
             Self::Id => ColumnType::BigInteger.def(),
             Self::AssetId => ColumnType::Binary.def(),
             Self::GroupKey => ColumnType::Text.def(),
-            Self::GroupValue => ColumnType::Text.def(),
-            Self::Seq => ColumnType::BigInteger.def(),
-            Self::SlotUpdated => ColumnType::BigInteger.def(),
+            Self::GroupValue => ColumnType::Text.def().null(),
+            Self::Seq => ColumnType::BigInteger.def().null(),
+            Self::SlotUpdated => ColumnType::BigInteger.def().null(),
             Self::Verified => ColumnType::Boolean.def().null(),
         }
     }

--- a/digital_asset_types/src/dao/generated/asset_grouping.rs
+++ b/digital_asset_types/src/dao/generated/asset_grouping.rs
@@ -21,6 +21,7 @@ pub struct Model {
     pub seq: Option<i64>,
     pub slot_updated: Option<i64>,
     pub verified: bool,
+    pub group_info_seq: Option<i64>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -32,6 +33,7 @@ pub enum Column {
     Seq,
     SlotUpdated,
     Verified,
+    GroupInfoSeq,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -62,6 +64,7 @@ impl ColumnTrait for Column {
             Self::Seq => ColumnType::BigInteger.def().null(),
             Self::SlotUpdated => ColumnType::BigInteger.def().null(),
             Self::Verified => ColumnType::Boolean.def(),
+            Self::GroupInfoSeq => ColumnType::BigInteger.def().null(),
         }
     }
 }

--- a/digital_asset_types/src/dao/generated/asset_grouping.rs
+++ b/digital_asset_types/src/dao/generated/asset_grouping.rs
@@ -20,6 +20,7 @@ pub struct Model {
     pub group_value: String,
     pub seq: i64,
     pub slot_updated: i64,
+    pub verified: Option<bool>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -30,6 +31,7 @@ pub enum Column {
     GroupValue,
     Seq,
     SlotUpdated,
+    Verified,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -59,6 +61,7 @@ impl ColumnTrait for Column {
             Self::GroupValue => ColumnType::Text.def(),
             Self::Seq => ColumnType::BigInteger.def(),
             Self::SlotUpdated => ColumnType::BigInteger.def(),
+            Self::Verified => ColumnType::Boolean.def().null(),
         }
     }
 }

--- a/digital_asset_types/src/dao/generated/sea_orm_active_enums.rs
+++ b/digital_asset_types/src/dao/generated/sea_orm_active_enums.rs
@@ -4,66 +4,12 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(
-    rs_type = "String",
-    db_type = "Enum",
-    enum_name = "specification_versions"
-)]
-pub enum SpecificationVersions {
-    #[sea_orm(string_value = "unknown")]
-    Unknown,
-    #[sea_orm(string_value = "v0")]
-    V0,
-    #[sea_orm(string_value = "v1")]
-    V1,
-    #[sea_orm(string_value = "v2")]
-    V2,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "task_status")]
-pub enum TaskStatus {
-    #[sea_orm(string_value = "failed")]
-    Failed,
-    #[sea_orm(string_value = "pending")]
-    Pending,
-    #[sea_orm(string_value = "running")]
-    Running,
-    #[sea_orm(string_value = "success")]
-    Success,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "mutability")]
 pub enum Mutability {
     #[sea_orm(string_value = "immutable")]
     Immutable,
     #[sea_orm(string_value = "mutable")]
     Mutable,
-    #[sea_orm(string_value = "unknown")]
-    Unknown,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(
-    rs_type = "String",
-    db_type = "Enum",
-    enum_name = "royalty_target_type"
-)]
-pub enum RoyaltyTargetType {
-    #[sea_orm(string_value = "creators")]
-    Creators,
-    #[sea_orm(string_value = "fanout")]
-    Fanout,
-    #[sea_orm(string_value = "single")]
-    Single,
-    #[sea_orm(string_value = "unknown")]
-    Unknown,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "owner_type")]
-pub enum OwnerType {
-    #[sea_orm(string_value = "single")]
-    Single,
-    #[sea_orm(string_value = "token")]
-    Token,
     #[sea_orm(string_value = "unknown")]
     Unknown,
 }
@@ -86,12 +32,30 @@ pub enum V1AccountAttachments {
     Unknown,
 }
 #[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "chain_mutability")]
-pub enum ChainMutability {
-    #[sea_orm(string_value = "immutable")]
-    Immutable,
-    #[sea_orm(string_value = "mutable")]
-    Mutable,
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "task_status")]
+pub enum TaskStatus {
+    #[sea_orm(string_value = "failed")]
+    Failed,
+    #[sea_orm(string_value = "pending")]
+    Pending,
+    #[sea_orm(string_value = "running")]
+    Running,
+    #[sea_orm(string_value = "success")]
+    Success,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(
+    rs_type = "String",
+    db_type = "Enum",
+    enum_name = "royalty_target_type"
+)]
+pub enum RoyaltyTargetType {
+    #[sea_orm(string_value = "creators")]
+    Creators,
+    #[sea_orm(string_value = "fanout")]
+    Fanout,
+    #[sea_orm(string_value = "single")]
+    Single,
     #[sea_orm(string_value = "unknown")]
     Unknown,
 }
@@ -120,6 +84,42 @@ pub enum SpecificationAssetClass {
     ProgrammableNft,
     #[sea_orm(string_value = "TRANSFER_RESTRICTED_NFT")]
     TransferRestrictedNft,
+    #[sea_orm(string_value = "unknown")]
+    Unknown,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "chain_mutability")]
+pub enum ChainMutability {
+    #[sea_orm(string_value = "immutable")]
+    Immutable,
+    #[sea_orm(string_value = "mutable")]
+    Mutable,
+    #[sea_orm(string_value = "unknown")]
+    Unknown,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(
+    rs_type = "String",
+    db_type = "Enum",
+    enum_name = "specification_versions"
+)]
+pub enum SpecificationVersions {
+    #[sea_orm(string_value = "unknown")]
+    Unknown,
+    #[sea_orm(string_value = "v0")]
+    V0,
+    #[sea_orm(string_value = "v1")]
+    V1,
+    #[sea_orm(string_value = "v2")]
+    V2,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "owner_type")]
+pub enum OwnerType {
+    #[sea_orm(string_value = "single")]
+    Single,
+    #[sea_orm(string_value = "token")]
+    Token,
     #[sea_orm(string_value = "unknown")]
     Unknown,
 }

--- a/digital_asset_types/src/dao/generated/sea_orm_active_enums.rs
+++ b/digital_asset_types/src/dao/generated/sea_orm_active_enums.rs
@@ -4,12 +4,84 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "task_status")]
+pub enum TaskStatus {
+    #[sea_orm(string_value = "failed")]
+    Failed,
+    #[sea_orm(string_value = "pending")]
+    Pending,
+    #[sea_orm(string_value = "running")]
+    Running,
+    #[sea_orm(string_value = "success")]
+    Success,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(
+    rs_type = "String",
+    db_type = "Enum",
+    enum_name = "specification_versions"
+)]
+pub enum SpecificationVersions {
+    #[sea_orm(string_value = "unknown")]
+    Unknown,
+    #[sea_orm(string_value = "v0")]
+    V0,
+    #[sea_orm(string_value = "v1")]
+    V1,
+    #[sea_orm(string_value = "v2")]
+    V2,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "owner_type")]
+pub enum OwnerType {
+    #[sea_orm(string_value = "single")]
+    Single,
+    #[sea_orm(string_value = "token")]
+    Token,
+    #[sea_orm(string_value = "unknown")]
+    Unknown,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "mutability")]
 pub enum Mutability {
     #[sea_orm(string_value = "immutable")]
     Immutable,
     #[sea_orm(string_value = "mutable")]
     Mutable,
+    #[sea_orm(string_value = "unknown")]
+    Unknown,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(
+    rs_type = "String",
+    db_type = "Enum",
+    enum_name = "v1_account_attachments"
+)]
+pub enum V1AccountAttachments {
+    #[sea_orm(string_value = "edition")]
+    Edition,
+    #[sea_orm(string_value = "edition_marker")]
+    EditionMarker,
+    #[sea_orm(string_value = "master_edition_v1")]
+    MasterEditionV1,
+    #[sea_orm(string_value = "master_edition_v2")]
+    MasterEditionV2,
+    #[sea_orm(string_value = "unknown")]
+    Unknown,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(
+    rs_type = "String",
+    db_type = "Enum",
+    enum_name = "royalty_target_type"
+)]
+pub enum RoyaltyTargetType {
+    #[sea_orm(string_value = "creators")]
+    Creators,
+    #[sea_orm(string_value = "fanout")]
+    Fanout,
+    #[sea_orm(string_value = "single")]
+    Single,
     #[sea_orm(string_value = "unknown")]
     Unknown,
 }
@@ -40,78 +112,6 @@ pub enum SpecificationAssetClass {
     TransferRestrictedNft,
     #[sea_orm(string_value = "unknown")]
     Unknown,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(
-    rs_type = "String",
-    db_type = "Enum",
-    enum_name = "specification_versions"
-)]
-pub enum SpecificationVersions {
-    #[sea_orm(string_value = "unknown")]
-    Unknown,
-    #[sea_orm(string_value = "v0")]
-    V0,
-    #[sea_orm(string_value = "v1")]
-    V1,
-    #[sea_orm(string_value = "v2")]
-    V2,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(
-    rs_type = "String",
-    db_type = "Enum",
-    enum_name = "v1_account_attachments"
-)]
-pub enum V1AccountAttachments {
-    #[sea_orm(string_value = "edition")]
-    Edition,
-    #[sea_orm(string_value = "edition_marker")]
-    EditionMarker,
-    #[sea_orm(string_value = "master_edition_v1")]
-    MasterEditionV1,
-    #[sea_orm(string_value = "master_edition_v2")]
-    MasterEditionV2,
-    #[sea_orm(string_value = "unknown")]
-    Unknown,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "owner_type")]
-pub enum OwnerType {
-    #[sea_orm(string_value = "single")]
-    Single,
-    #[sea_orm(string_value = "token")]
-    Token,
-    #[sea_orm(string_value = "unknown")]
-    Unknown,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(
-    rs_type = "String",
-    db_type = "Enum",
-    enum_name = "royalty_target_type"
-)]
-pub enum RoyaltyTargetType {
-    #[sea_orm(string_value = "creators")]
-    Creators,
-    #[sea_orm(string_value = "fanout")]
-    Fanout,
-    #[sea_orm(string_value = "single")]
-    Single,
-    #[sea_orm(string_value = "unknown")]
-    Unknown,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "task_status")]
-pub enum TaskStatus {
-    #[sea_orm(string_value = "failed")]
-    Failed,
-    #[sea_orm(string_value = "pending")]
-    Pending,
-    #[sea_orm(string_value = "running")]
-    Running,
-    #[sea_orm(string_value = "success")]
-    Success,
 }
 #[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "chain_mutability")]

--- a/digital_asset_types/src/dao/generated/sea_orm_active_enums.rs
+++ b/digital_asset_types/src/dao/generated/sea_orm_active_enums.rs
@@ -4,18 +4,6 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "task_status")]
-pub enum TaskStatus {
-    #[sea_orm(string_value = "failed")]
-    Failed,
-    #[sea_orm(string_value = "pending")]
-    Pending,
-    #[sea_orm(string_value = "running")]
-    Running,
-    #[sea_orm(string_value = "success")]
-    Success,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
 #[sea_orm(
     rs_type = "String",
     db_type = "Enum",
@@ -32,22 +20,28 @@ pub enum SpecificationVersions {
     V2,
 }
 #[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "owner_type")]
-pub enum OwnerType {
-    #[sea_orm(string_value = "single")]
-    Single,
-    #[sea_orm(string_value = "token")]
-    Token,
-    #[sea_orm(string_value = "unknown")]
-    Unknown,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "mutability")]
-pub enum Mutability {
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "chain_mutability")]
+pub enum ChainMutability {
     #[sea_orm(string_value = "immutable")]
     Immutable,
     #[sea_orm(string_value = "mutable")]
     Mutable,
+    #[sea_orm(string_value = "unknown")]
+    Unknown,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(
+    rs_type = "String",
+    db_type = "Enum",
+    enum_name = "royalty_target_type"
+)]
+pub enum RoyaltyTargetType {
+    #[sea_orm(string_value = "creators")]
+    Creators,
+    #[sea_orm(string_value = "fanout")]
+    Fanout,
+    #[sea_orm(string_value = "single")]
+    Single,
     #[sea_orm(string_value = "unknown")]
     Unknown,
 }
@@ -70,18 +64,34 @@ pub enum V1AccountAttachments {
     Unknown,
 }
 #[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(
-    rs_type = "String",
-    db_type = "Enum",
-    enum_name = "royalty_target_type"
-)]
-pub enum RoyaltyTargetType {
-    #[sea_orm(string_value = "creators")]
-    Creators,
-    #[sea_orm(string_value = "fanout")]
-    Fanout,
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "owner_type")]
+pub enum OwnerType {
     #[sea_orm(string_value = "single")]
     Single,
+    #[sea_orm(string_value = "token")]
+    Token,
+    #[sea_orm(string_value = "unknown")]
+    Unknown,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "task_status")]
+pub enum TaskStatus {
+    #[sea_orm(string_value = "failed")]
+    Failed,
+    #[sea_orm(string_value = "pending")]
+    Pending,
+    #[sea_orm(string_value = "running")]
+    Running,
+    #[sea_orm(string_value = "success")]
+    Success,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "mutability")]
+pub enum Mutability {
+    #[sea_orm(string_value = "immutable")]
+    Immutable,
+    #[sea_orm(string_value = "mutable")]
+    Mutable,
     #[sea_orm(string_value = "unknown")]
     Unknown,
 }
@@ -110,16 +120,6 @@ pub enum SpecificationAssetClass {
     ProgrammableNft,
     #[sea_orm(string_value = "TRANSFER_RESTRICTED_NFT")]
     TransferRestrictedNft,
-    #[sea_orm(string_value = "unknown")]
-    Unknown,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "chain_mutability")]
-pub enum ChainMutability {
-    #[sea_orm(string_value = "immutable")]
-    Immutable,
-    #[sea_orm(string_value = "mutable")]
-    Mutable,
     #[sea_orm(string_value = "unknown")]
     Unknown,
 }

--- a/digital_asset_types/src/dao/generated/sea_orm_active_enums.rs
+++ b/digital_asset_types/src/dao/generated/sea_orm_active_enums.rs
@@ -20,8 +20,20 @@ pub enum SpecificationVersions {
     V2,
 }
 #[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "chain_mutability")]
-pub enum ChainMutability {
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "task_status")]
+pub enum TaskStatus {
+    #[sea_orm(string_value = "failed")]
+    Failed,
+    #[sea_orm(string_value = "pending")]
+    Pending,
+    #[sea_orm(string_value = "running")]
+    Running,
+    #[sea_orm(string_value = "success")]
+    Success,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "mutability")]
+pub enum Mutability {
     #[sea_orm(string_value = "immutable")]
     Immutable,
     #[sea_orm(string_value = "mutable")]
@@ -46,6 +58,16 @@ pub enum RoyaltyTargetType {
     Unknown,
 }
 #[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "owner_type")]
+pub enum OwnerType {
+    #[sea_orm(string_value = "single")]
+    Single,
+    #[sea_orm(string_value = "token")]
+    Token,
+    #[sea_orm(string_value = "unknown")]
+    Unknown,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
 #[sea_orm(
     rs_type = "String",
     db_type = "Enum",
@@ -64,30 +86,8 @@ pub enum V1AccountAttachments {
     Unknown,
 }
 #[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "owner_type")]
-pub enum OwnerType {
-    #[sea_orm(string_value = "single")]
-    Single,
-    #[sea_orm(string_value = "token")]
-    Token,
-    #[sea_orm(string_value = "unknown")]
-    Unknown,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "task_status")]
-pub enum TaskStatus {
-    #[sea_orm(string_value = "failed")]
-    Failed,
-    #[sea_orm(string_value = "pending")]
-    Pending,
-    #[sea_orm(string_value = "running")]
-    Running,
-    #[sea_orm(string_value = "success")]
-    Success,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "mutability")]
-pub enum Mutability {
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "chain_mutability")]
+pub enum ChainMutability {
     #[sea_orm(string_value = "immutable")]
     Immutable,
     #[sea_orm(string_value = "mutable")]

--- a/digital_asset_types/src/dao/scopes/asset.rs
+++ b/digital_asset_types/src/dao/scopes/asset.rs
@@ -65,7 +65,8 @@ pub async fn get_grouping(
         .filter(
             Condition::all()
                 .add(asset_grouping::Column::GroupKey.eq(group_key))
-                .add(asset_grouping::Column::GroupValue.eq(group_value)),
+                .add(asset_grouping::Column::GroupValue.eq(group_value))
+                .add(asset_grouping::Column::Verified.eq(true)),
         )
         .count(conn)
         .await?;
@@ -193,7 +194,7 @@ pub async fn get_related_for_assets(
         {
             let id = asset.id.clone();
             let fa = FullAsset {
-                asset: asset,
+                asset,
                 data: ad.clone(),
                 authorities: vec![],
                 creators: vec![],
@@ -229,6 +230,7 @@ pub async fn get_related_for_assets(
 
     let grouping = asset_grouping::Entity::find()
         .filter(asset_grouping::Column::AssetId.is_in(ids.clone()))
+        .filter(asset_grouping::Column::Verified.eq(true))
         .order_by_asc(asset_grouping::Column::AssetId)
         .all(conn)
         .await?;
@@ -289,6 +291,7 @@ pub async fn get_by_id(
         .await?;
     let grouping: Vec<asset_grouping::Model> = asset_grouping::Entity::find()
         .filter(asset_grouping::Column::AssetId.eq(asset.id.clone()))
+        .filter(asset_grouping::Column::Verified.eq(true))
         .all(conn)
         .await?;
     Ok(FullAsset {

--- a/digital_asset_types/src/dao/scopes/asset.rs
+++ b/digital_asset_types/src/dao/scopes/asset.rs
@@ -83,7 +83,8 @@ pub async fn get_by_grouping(
 ) -> Result<Vec<FullAsset>, DbErr> {
     let condition = asset_grouping::Column::GroupKey
         .eq(group_key)
-        .and(asset_grouping::Column::GroupValue.eq(group_value));
+        .and(asset_grouping::Column::GroupValue.eq(group_value))
+        .and(asset_grouping::Column::Verified.eq(true));
     get_by_related_condition(
         conn,
         Condition::all()

--- a/digital_asset_types/src/dapi/common/asset.rs
+++ b/digital_asset_types/src/dapi/common/asset.rs
@@ -253,7 +253,7 @@ pub fn to_grouping(groups: Vec<asset_grouping::Model>) -> Result<Vec<Group>, DbE
             group_value: model
                 .group_value
                 .clone()
-                .ok_or(DbErr::Custom("Specification version not found".to_string()))?,
+                .ok_or(DbErr::Custom("Group value not found".to_string()))?,
         })
     }
 

--- a/digital_asset_types/tests/common.rs
+++ b/digital_asset_types/tests/common.rs
@@ -229,6 +229,7 @@ pub fn create_asset_grouping(
             group_key: "collection".to_string(),
             slot_updated: Some(0),
             verified: false,
+            group_info_seq: Some(0),
         },
     )
 }

--- a/digital_asset_types/tests/common.rs
+++ b/digital_asset_types/tests/common.rs
@@ -228,7 +228,7 @@ pub fn create_asset_grouping(
             id: row_num,
             group_key: "collection".to_string(),
             slot_updated: Some(0),
-            verified: Some(false),
+            verified: false,
         },
     )
 }

--- a/digital_asset_types/tests/common.rs
+++ b/digital_asset_types/tests/common.rs
@@ -218,16 +218,17 @@ pub fn create_asset_grouping(
         asset_grouping::ActiveModel {
             asset_id: Set(asset_id.clone()),
             group_key: Set(String::from("collection")),
-            group_value: Set(bs58::encode(collection).into_string()),
+            group_value: Set(Some(bs58::encode(collection).into_string())),
             ..Default::default()
         },
         asset_grouping::Model {
             asset_id,
-            group_value: bs58::encode(collection).into_string(),
-            seq: 0,
+            group_value: Some(bs58::encode(collection).into_string()),
+            seq: Some(0),
             id: row_num,
             group_key: "collection".to_string(),
-            slot_updated: 0,
+            slot_updated: Some(0),
+            verified: Some(false),
         },
     )
 }

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -22,6 +22,7 @@ mod m20230615_120101_remove_asset_null_constraints;
 mod m20230620_120101_add_was_decompressed;
 mod m20230623_120101_add_leaf_sequence_number;
 mod m20230712_120101_remove_asset_creators_null_constraints;
+mod m20230720_120101_add_asset_grouping_verified;
 
 pub struct Migrator;
 
@@ -51,6 +52,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230620_120101_add_was_decompressed::Migration),
             Box::new(m20230623_120101_add_leaf_sequence_number::Migration),
             Box::new(m20230712_120101_remove_asset_creators_null_constraints::Migration),
+            Box::new(m20230720_120101_add_asset_grouping_verified::Migration),
         ]
     }
 }

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -23,6 +23,7 @@ mod m20230620_120101_add_was_decompressed;
 mod m20230623_120101_add_leaf_sequence_number;
 mod m20230712_120101_remove_asset_creators_null_constraints;
 mod m20230720_120101_add_asset_grouping_verified;
+mod m20230720_130101_remove_asset_grouping_null_constraints;
 
 pub struct Migrator;
 
@@ -53,6 +54,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230623_120101_add_leaf_sequence_number::Migration),
             Box::new(m20230712_120101_remove_asset_creators_null_constraints::Migration),
             Box::new(m20230720_120101_add_asset_grouping_verified::Migration),
+            Box::new(m20230720_130101_remove_asset_grouping_null_constraints::Migration),
         ]
     }
 }

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -24,6 +24,7 @@ mod m20230623_120101_add_leaf_sequence_number;
 mod m20230712_120101_remove_asset_creators_null_constraints;
 mod m20230720_120101_add_asset_grouping_verified;
 mod m20230720_130101_remove_asset_grouping_null_constraints;
+mod m20230724_120101_add_group_info_seq;
 
 pub struct Migrator;
 
@@ -55,6 +56,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230712_120101_remove_asset_creators_null_constraints::Migration),
             Box::new(m20230720_120101_add_asset_grouping_verified::Migration),
             Box::new(m20230720_130101_remove_asset_grouping_null_constraints::Migration),
+            Box::new(m20230724_120101_add_group_info_seq::Migration),
         ]
     }
 }

--- a/migration/src/m20230720_120101_add_asset_grouping_verified.rs
+++ b/migration/src/m20230720_120101_add_asset_grouping_verified.rs
@@ -1,0 +1,32 @@
+use digital_asset_types::dao::asset_grouping;
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Replace the sample below with your own migration scripts
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(asset_grouping::Entity)
+                    .add_column(ColumnDef::new(Alias::new("verified")).boolean())
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Replace the sample below with your own migration scripts
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(asset_grouping::Entity)
+                    .drop_column(Alias::new("verified"))
+                    .to_owned(),
+            )
+            .await
+    }
+}

--- a/migration/src/m20230720_120101_add_asset_grouping_verified.rs
+++ b/migration/src/m20230720_120101_add_asset_grouping_verified.rs
@@ -12,7 +12,12 @@ impl MigrationTrait for Migration {
             .alter_table(
                 Table::alter()
                     .table(asset_grouping::Entity)
-                    .add_column(ColumnDef::new(Alias::new("verified")).boolean())
+                    .add_column(
+                        ColumnDef::new(Alias::new("verified"))
+                            .boolean()
+                            .not_null()
+                            .default(false),
+                    )
                     .to_owned(),
             )
             .await

--- a/migration/src/m20230720_130101_remove_asset_grouping_null_constraints.rs
+++ b/migration/src/m20230720_130101_remove_asset_grouping_null_constraints.rs
@@ -1,0 +1,46 @@
+use sea_orm_migration::{
+    prelude::*,
+    sea_orm::{ConnectionTrait, DatabaseBackend, Statement},
+};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute(Statement::from_string(
+                DatabaseBackend::Postgres,
+                "
+                ALTER TABLE asset_grouping
+                ALTER COLUMN group_value DROP NOT NULL,
+                ALTER COLUMN seq DROP NOT NULL,
+                ALTER COLUMN slot_updated DROP NOT NULL;
+                "
+                .to_string(),
+            ))
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute(Statement::from_string(
+                DatabaseBackend::Postgres,
+                "
+                ALTER TABLE asset_grouping
+                ALTER COLUMN group_value SET NOT NULL,
+                ALTER COLUMN seq SET NOT NULL,
+                ALTER COLUMN slot_updated SET NOT NULL;
+                "
+                .to_string(),
+            ))
+            .await?;
+
+        Ok(())
+    }
+}

--- a/migration/src/m20230724_120101_add_group_info_seq.rs
+++ b/migration/src/m20230724_120101_add_group_info_seq.rs
@@ -1,0 +1,36 @@
+use digital_asset_types::dao::asset_grouping;
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Replace the sample below with your own migration scripts
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(asset_grouping::Entity)
+                    .add_column(ColumnDef::new(Alias::new("group_info_seq")).big_integer())
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Replace the sample below with your own migration scripts
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(asset_grouping::Entity)
+                    .drop_column(Alias::new("group_info_seq"))
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/nft_ingester/src/account_updates.rs
+++ b/nft_ingester/src/account_updates.rs
@@ -1,10 +1,7 @@
-use std::{
-    sync::Arc,
-};
+use std::sync::Arc;
 
 use crate::{
-    metric, metrics::capture_result,
-    program_transformers::ProgramTransformer, tasks::TaskData,
+    metric, metrics::capture_result, program_transformers::ProgramTransformer, tasks::TaskData,
 };
 use cadence_macros::{is_global_default_set, statsd_count, statsd_time};
 use chrono::Utc;

--- a/nft_ingester/src/program_transformers/bubblegum/collection_verification.rs
+++ b/nft_ingester/src/program_transformers/bubblegum/collection_verification.rs
@@ -70,9 +70,9 @@ where
                         let grouping = asset_grouping::ActiveModel {
                             asset_id: Set(id_bytes.to_vec()),
                             group_key: Set("collection".to_string()),
-                            group_value: Set(collection.to_string()),
-                            seq: Set(seq as i64),
-                            slot_updated: Set(bundle.slot as i64),
+                            group_value: Set(Some(collection.to_string())),
+                            seq: Set(Some(seq as i64)),
+                            slot_updated: Set(Some(bundle.slot as i64)),
                             ..Default::default()
                         };
                         let mut query = asset_grouping::Entity::insert(grouping)

--- a/nft_ingester/src/program_transformers/bubblegum/creator_verification.rs
+++ b/nft_ingester/src/program_transformers/bubblegum/creator_verification.rs
@@ -2,7 +2,7 @@ use crate::{
     error::IngesterError,
     program_transformers::bubblegum::{
         save_changelog_event, upsert_asset_with_leaf_info,
-        upsert_asset_with_owner_and_delegate_info, upsert_asset_with_seq, upsert_creator,
+        upsert_asset_with_owner_and_delegate_info, upsert_asset_with_seq, upsert_creator_verified,
     },
 };
 use blockbuster::{
@@ -78,7 +78,7 @@ where
             _ => return Err(IngesterError::NotImplemented),
         };
 
-        upsert_creator(
+        upsert_creator_verified(
             txn,
             asset_id_bytes,
             creator.to_bytes().to_vec(),

--- a/nft_ingester/src/program_transformers/bubblegum/db.rs
+++ b/nft_ingester/src/program_transformers/bubblegum/db.rs
@@ -340,7 +340,7 @@ where
         .build(DbBackend::Postgres);
 
     query.sql = format!(
-        "{} WHERE excluded.group_info_seq > asset_grouping.group_info_seq",
+        "{} WHERE excluded.group_info_seq > asset_grouping.group_info_seq OR asset_grouping.group_info_seq IS NULL",
         query.sql
     );
 
@@ -382,7 +382,10 @@ where
         )
         .build(DbBackend::Postgres);
 
-    query.sql = format!("{} WHERE excluded.seq > asset_grouping.seq", query.sql);
+    query.sql = format!(
+        "{} WHERE excluded.seq > asset_grouping.seq OR asset_grouping.seq IS NULL",
+        query.sql
+    );
 
     txn.execute(query)
         .await

--- a/nft_ingester/src/program_transformers/bubblegum/db.rs
+++ b/nft_ingester/src/program_transformers/bubblegum/db.rs
@@ -320,7 +320,7 @@ where
         group_key: Set("collection".to_string()),
         group_value: Set(Some(group_value)),
         slot_updated: Set(Some(slot_updated)),
-        //base_info_seq: seq: Set(Some(seq)),
+        //group_info_seq: seq: Set(Some(seq)),
         ..Default::default()
     };
 
@@ -340,7 +340,7 @@ where
         .build(DbBackend::Postgres);
 
     // query.sql = format!(
-    //     "{} WHERE excluded.base_info_seq > asset_grouping.base_info_seq",
+    //     "{} WHERE excluded.group_info_seq > asset_grouping.group_info_seq",
     //     query.sql
     // );
 

--- a/nft_ingester/src/program_transformers/bubblegum/mint_v1.rs
+++ b/nft_ingester/src/program_transformers/bubblegum/mint_v1.rs
@@ -1,9 +1,8 @@
-use super::save_changelog_event;
 use crate::{
     error::IngesterError,
     program_transformers::bubblegum::{
-        upsert_asset_with_compression_info, upsert_asset_with_leaf_info,
-        upsert_asset_with_owner_and_delegate_info, upsert_asset_with_seq,
+        save_changelog_event, upsert_asset_with_compression_info, upsert_asset_with_leaf_info,
+        upsert_asset_with_owner_and_delegate_info, upsert_asset_with_seq, upsert_collection,
     },
     tasks::{DownloadMetadata, IntoTaskData, TaskData},
 };
@@ -325,33 +324,35 @@ where
                     .build(DbBackend::Postgres);
                 txn.execute(query).await?;
 
-                // Insert into `asset_grouping` table.
+                // Upsert into `asset_grouping` table with base collection info.
                 if let Some(c) = &metadata.collection {
-                    if c.verified {
-                        let model = asset_grouping::ActiveModel {
-                            asset_id: Set(id_bytes.to_vec()),
-                            group_key: Set("collection".to_string()),
-                            group_value: Set(Some(c.key.to_string())),
-                            seq: Set(Some(seq as i64)), // gummyroll seq
-                            slot_updated: Set(Some(slot_i)),
-                            ..Default::default()
-                        };
+                    let model = asset_grouping::ActiveModel {
+                        asset_id: Set(id_bytes.to_vec()),
+                        group_key: Set("collection".to_string()),
+                        group_value: Set(Some(c.key.to_string())),
+                        slot_updated: Set(Some(slot_i)),
+                        ..Default::default()
+                    };
 
-                        // Do not attempt to modify any existing values:
-                        // `ON CONFLICT ('asset_id') DO NOTHING`.
-                        let query = asset_grouping::Entity::insert(model)
-                            .on_conflict(
-                                OnConflict::columns([
-                                    asset_grouping::Column::AssetId,
-                                    asset_grouping::Column::GroupKey,
-                                ])
-                                .do_nothing()
-                                .to_owned(),
-                            )
-                            .build(DbBackend::Postgres);
-                        txn.execute(query).await?;
-                    }
+                    let query = asset_grouping::Entity::insert(model)
+                        .on_conflict(
+                            OnConflict::columns([
+                                asset_grouping::Column::AssetId,
+                                asset_grouping::Column::GroupKey,
+                            ])
+                            .update_columns([
+                                asset_grouping::Column::GroupValue,
+                                asset_grouping::Column::SlotUpdated,
+                            ])
+                            .to_owned(),
+                        )
+                        .build(DbBackend::Postgres);
+                    txn.execute(query).await?;
+
+                    // Partial update with whether collection is verified and the `seq` number.
+                    upsert_collection(txn, id_bytes.to_vec(), c.verified, seq as i64).await?;
                 }
+
                 let mut task = DownloadMetadata {
                     asset_data_id: id_bytes.to_vec(),
                     uri: metadata.uri.clone(),

--- a/nft_ingester/src/program_transformers/bubblegum/mint_v1.rs
+++ b/nft_ingester/src/program_transformers/bubblegum/mint_v1.rs
@@ -331,9 +331,9 @@ where
                         let model = asset_grouping::ActiveModel {
                             asset_id: Set(id_bytes.to_vec()),
                             group_key: Set("collection".to_string()),
-                            group_value: Set(c.key.to_string()),
-                            seq: Set(seq as i64), // gummyroll seq
-                            slot_updated: Set(slot_i),
+                            group_value: Set(Some(c.key.to_string())),
+                            seq: Set(Some(seq as i64)), // gummyroll seq
+                            slot_updated: Set(Some(slot_i)),
                             ..Default::default()
                         };
 

--- a/nft_ingester/src/program_transformers/token_metadata/v1_asset.rs
+++ b/nft_ingester/src/program_transformers/token_metadata/v1_asset.rs
@@ -317,9 +317,9 @@ pub async fn save_v1_asset<T: ConnectionTrait + TransactionTrait>(
             let model = asset_grouping::ActiveModel {
                 asset_id: Set(id.to_vec()),
                 group_key: Set("collection".to_string()),
-                group_value: Set(c.key.to_string()),
-                seq: Set(0),
-                slot_updated: Set(slot_i),
+                group_value: Set(Some(c.key.to_string())),
+                seq: Set(Some(0)),
+                slot_updated: Set(Some(slot_i)),
                 ..Default::default()
             };
             let mut query = asset_grouping::Entity::insert(model)


### PR DESCRIPTION
### Notes
* This PR is based on https://github.com/metaplex-foundation/digital-asset-rpc-infrastructure/pull/77 and https://github.com/metaplex-foundation/digital-asset-rpc-infrastructure/pull/87
* It adds support for collection verification to be indexed with out of order transactions.
* It also adds a `verified` flag so that collection verification is indexed properly.

### Testing
* Verified by running a multiple sequences in order and in reverse order, and either way get same end result in `asset` and `asset_grouping` tables.
* Verified that when a collection is unverified, `getAsset` returns empty grouping.  Then after the collection is verified, `getAsset` returns the collection as a grouping.  This is to remain consistent with existing API behavior.
* See https://github.com/metaplex-foundation/digital-asset-rpc-infrastructure/pull/77#issue-1724765232 for more info on overall testing process.

| Transaction sequence | Database result | `getAsset` result | 
| ----------- | ----------- | ----------- |
| `CreateTree`/`Mint`, `VerifyCollection` | OK - `asset`, `asset_grouping`, `cl_items` match when PR code run forwards and backwards.  PR code's `asset` and `cl_items` tables consistent with mainline code run forwards.  `asset_grouping` incorrect on main. | OK - Using PR code, no grouping returned before verified, grouping returned after verified. |
| `CreateTree`/`Mint`, `VerifyCollection`, `UnverifyCollection` | OK - `asset`, `asset_grouping`, `cl_items` match when PR code is run forwards and backwards. | OK - Using PR code, grouping returned after verified, no longer returned after unverified. |
| `CreateTree`/`Mint`, `SetAndVerifyCollection` | `SetAndVerifyCollection` does not parse properly due to Blockbuster error.  Not a regression. | `SetAndVerifyCollection` does not parse properly due to Blockbuster error.  Not a regression. |
| `CreateTree`/`MintToCollection`, `UnverifyCollection` | OK - `asset`, `asset_grouping`, `cl_items `match when PR code is run forwards and backwards. | OK - Using PR code, grouping returned after verified, no longer returned after unverified. |
