### PR TITLE
Update to Rust 1.69 docker image

### DIFF
--- a/Api.Dockerfile
+++ b/Api.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.65-bullseye AS chef
+FROM rust:1.69-bullseye AS chef
 RUN cargo install cargo-chef
 FROM chef AS planner
 COPY das_api /rust/das_api/
@@ -19,7 +19,7 @@ COPY das_api .
 # Build application
 RUN cargo build --release
 
-FROM rust:1.65-slim-bullseye
+FROM rust:1.69-slim-bullseye
 ARG APP=/usr/src/app
 RUN apt update \
     && apt install -y curl ca-certificates tzdata \

--- a/Ingest.Dockerfile
+++ b/Ingest.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.65-bullseye AS chef
+FROM rust:1.69-bullseye AS chef
 RUN cargo install cargo-chef
 FROM chef AS planner
 COPY nft_ingester /rust/nft_ingester/
@@ -19,7 +19,7 @@ COPY nft_ingester .
 # Build application
 RUN cargo build --release
 
-FROM rust:1.65-slim-bullseye
+FROM rust:1.69-slim-bullseye
 ARG APP=/usr/src/app
 RUN apt update \
     && apt install -y curl ca-certificates tzdata \

--- a/Load.Dockerfile
+++ b/Load.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.65-bullseye AS chef
+FROM rust:1.69-bullseye AS chef
 RUN cargo install cargo-chef
 FROM chef AS planner
 COPY tests/load_generation /rust/load_generation/

--- a/Migrator.Dockerfile
+++ b/Migrator.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.65-bullseye
+FROM rust:1.69-bullseye
 COPY init.sql /init.sql
 COPY migration /migration
 ENV INIT_FILE_PATH=/init.sql

--- a/Proxy.Dockerfile
+++ b/Proxy.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.65-bullseye AS builder
+FROM rust:1.69-bullseye AS builder
 COPY ./metaplex-rpc-proxy /rust/metaplex-rpc-proxy
 WORKDIR /rust/metaplex-rpc-proxy
 RUN cargo install wasm-pack


### PR DESCRIPTION
Some of the deps no longer build with 1.65

After updating to the Rust 1.69 image Docker builds again.
