### PR TITLE
Moved version metric

### DIFF
--- a/nft_ingester/src/main.rs
+++ b/nft_ingester/src/main.rs
@@ -161,7 +161,7 @@ pub async fn main() -> Result<(), IngesterError> {
 
     let roles_str = role.to_string();
     metric! {
-        statsd_count!("ingester.startup", 1, "role" => &roles_str);
+        statsd_count!("ingester.startup", 1, "role" => &roles_str, "version" => config.code_version.unwrap_or("unknown"));
     }
     match signal::ctrl_c().await {
         Ok(()) => {}

--- a/nft_ingester/src/metrics.rs
+++ b/nft_ingester/src/metrics.rs
@@ -6,7 +6,7 @@ use log::error;
 use tokio::time::Instant;
 
 use crate::{
-    config::{IngesterConfig, CODE_VERSION},
+    config::IngesterConfig,
     error::IngesterError,
 };
 
@@ -34,7 +34,6 @@ pub fn setup_metrics(config: &IngesterConfig) {
         let builder = StatsdClient::builder("das_ingester", queuing_sink);
         let client = builder
             .with_tag("env", env)
-            .with_tag("version", CODE_VERSION)
             .build();
         set_global_default(client);
     }


### PR DESCRIPTION
Based on Nick's comments it seems it was annoying to keep the version metric in every metric reported. Can be moved to only having it on the startup metric report.