### PR TITLE
Fix collection updates for regular nfts

### DIFF
--- a/nft_ingester/src/program_transformers/token_metadata/v1_asset.rs
+++ b/nft_ingester/src/program_transformers/token_metadata/v1_asset.rs
@@ -340,9 +340,9 @@ pub async fn save_v1_asset<T: ConnectionTrait + TransactionTrait>(
             )
             .build(DbBackend::Postgres);
         query.sql = format!(
-                "{} WHERE excluded.slot_updated > asset_grouping.slot_updated AND excluded.seq >= asset_grouping.seq",
-                query.sql
-            );
+            "{} WHERE excluded.slot_updated > asset_grouping.slot_updated",
+            query.sql
+        );
         txn.execute(query)
             .await
             .map_err(|db_err| IngesterError::AssetIndexError(db_err.to_string()))?;


### PR DESCRIPTION
Collection updates were not properly indexing. If a collection does not have a seq value, the upsert condition is never met and the update is skipped. We do not need to check seq for regular NFTs since "recompression" is not live yet.

Tested locally via collection updates.