### PR TITLE
fix: allow no metadata for cnft mints

### DIFF
--- a/nft_ingester/src/program_transformers/bubblegum/mod.rs
+++ b/nft_ingester/src/program_transformers/bubblegum/mod.rs
@@ -70,7 +70,9 @@ where
         InstructionName::MintV1 | InstructionName::MintToCollectionV1 => {
             let task = mint_v1::mint_v1(parsing_result, bundle, txn, cl_audits).await?;
 
-            task_manager.send(task)?;
+            if let Some(t) = task {
+                task_manager.send(t)?;
+            }
         }
         InstructionName::Redeem => {
             redeem::redeem(parsing_result, bundle, txn, cl_audits).await?;


### PR DESCRIPTION
# Overview

Bubblegum allows for empty URIs. When this happens, the indexer will reject the transaction leading to a missing NFT in the API response. To fix, we allow the record to index and skip the off-chain indexing update.

# Testing
Running in Helius fork in prod.
Keep in mind that we are 1.14 for ingester at the moment, so I have not perfectly reproduced these changes on the Metaplex version. The changes are simple though and should be fine.