### PR TITLE
Update test validator in docker and blockbuster version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,8 +881,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blockbuster"
-version = "0.8.0"
-source = "git+https://github.com/metaplex-foundation/blockbuster.git?rev=e5d96d62969af42ce1c7f10cca88dc1c4f643598#e5d96d62969af42ce1c7f10cca88dc1c4f643598"
+version = "0.9.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e0240c1218958c0d51284d783fa055f551d769bb8b7a4abf635b17fa9620dc"
 dependencies = [
  "anchor-lang",
  "async-trait",
@@ -2881,9 +2882,9 @@ dependencies = [
 
 [[package]]
 name = "mpl-bubblegum"
-version = "1.0.1-beta.2"
+version = "1.0.1-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b271e10afc5a53a0615455b7cf9bb0901f65a1aae99e4cfe6290ff4eb6e21634"
+checksum = "29346f26192bb7f73330196fde4c8cfb35675bf1a4b026cd088f7ca8fda69f3f"
 dependencies = [
  "borsh 0.10.3",
  "kaigan",

--- a/das_api/Cargo.lock
+++ b/das_api/Cargo.lock
@@ -668,8 +668,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blockbuster"
-version = "0.8.0"
-source = "git+https://github.com/metaplex-foundation/blockbuster.git?rev=e5d96d62969af42ce1c7f10cca88dc1c4f643598#e5d96d62969af42ce1c7f10cca88dc1c4f643598"
+version = "0.9.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e0240c1218958c0d51284d783fa055f551d769bb8b7a4abf635b17fa9620dc"
 dependencies = [
  "anchor-lang",
  "async-trait",
@@ -2484,9 +2485,9 @@ dependencies = [
 
 [[package]]
 name = "mpl-bubblegum"
-version = "1.0.1-beta.2"
+version = "1.0.1-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b271e10afc5a53a0615455b7cf9bb0901f65a1aae99e4cfe6290ff4eb6e21634"
+checksum = "29346f26192bb7f73330196fde4c8cfb35675bf1a4b026cd088f7ca8fda69f3f"
 dependencies = [
  "borsh 0.10.3",
  "kaigan",

--- a/das_api/Cargo.toml
+++ b/das_api/Cargo.toml
@@ -33,9 +33,9 @@ schemars = "0.8.6"
 schemars_derive = "0.8.6"
 open-rpc-derive = { version = "0.0.4"}
 open-rpc-schema = { version = "0.0.4"}
-blockbuster = { git = "https://github.com/metaplex-foundation/blockbuster.git", rev = "e5d96d62969af42ce1c7f10cca88dc1c4f643598" }
+blockbuster = "0.9.0-beta.1"
 anchor-lang = "0.28.0"
 mpl-token-metadata = { version = "=2.0.0-beta.1",  features = ["serde-feature"] }
 mpl-candy-machine-core = { version = "2.0.1", features = ["no-entrypoint"] }
-mpl-bubblegum = "1.0.1-beta.2"
+mpl-bubblegum = "1.0.1-beta.3"
 mpl-candy-guard = { version = "2.0.0", features = ["no-entrypoint"] }

--- a/digital_asset_types/Cargo.toml
+++ b/digital_asset_types/Cargo.toml
@@ -18,7 +18,7 @@ solana-sdk = "~1.16.16"
 num-traits = "0.2.15"
 num-derive = "0.3.3"
 thiserror = "1.0.31"
-blockbuster = { git = "https://github.com/metaplex-foundation/blockbuster.git", rev = "e5d96d62969af42ce1c7f10cca88dc1c4f643598" }
+blockbuster = "0.9.0-beta.1"
 jsonpath_lib = "0.3.0"
 mime_guess = "2.0.4"
 url = "2.3.1"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -89,7 +89,7 @@ services:
     volumes:
       - ./db-data/:/var/lib/postgresql/data/:rw
   solana:
-    image: ghcr.io/metaplex-foundation/plerkle-test-validator:v1.5.1-1.64.0-v1.14.15
+    image: ghcr.io/metaplex-foundation/plerkle-test-validator:v1.6.0-1.69.0-v1.16.6
     volumes:
     - ./programs:/so/:ro
     - ./ledger:/config:rw

--- a/migration/Cargo.lock
+++ b/migration/Cargo.lock
@@ -755,8 +755,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blockbuster"
-version = "0.8.0"
-source = "git+https://github.com/metaplex-foundation/blockbuster.git?rev=e5d96d62969af42ce1c7f10cca88dc1c4f643598#e5d96d62969af42ce1c7f10cca88dc1c4f643598"
+version = "0.9.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e0240c1218958c0d51284d783fa055f551d769bb8b7a4abf635b17fa9620dc"
 dependencies = [
  "anchor-lang",
  "async-trait",
@@ -2453,9 +2454,9 @@ dependencies = [
 
 [[package]]
 name = "mpl-bubblegum"
-version = "1.0.1-beta.2"
+version = "1.0.1-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b271e10afc5a53a0615455b7cf9bb0901f65a1aae99e4cfe6290ff4eb6e21634"
+checksum = "29346f26192bb7f73330196fde4c8cfb35675bf1a4b026cd088f7ca8fda69f3f"
 dependencies = [
  "borsh 0.10.3",
  "kaigan",

--- a/nft_ingester/Cargo.toml
+++ b/nft_ingester/Cargo.toml
@@ -29,13 +29,13 @@ flatbuffers = "23.1.21"
 lazy_static = "1.4.0"
 regex = "1.5.5"
 digital_asset_types = { path = "../digital_asset_types", features = ["json_types", "sql_types"] }
-mpl-bubblegum = "1.0.1-beta.2"
+mpl-bubblegum = "1.0.1-beta.3"
 spl-account-compression = { version = "0.2.0", features = ["no-entrypoint"] }
 spl-concurrent-merkle-tree = "0.2.0"
 uuid = "1.0.0"
 async-trait = "0.1.53"
 num-traits = "0.2.15"
-blockbuster = { git = "https://github.com/metaplex-foundation/blockbuster.git", rev = "e5d96d62969af42ce1c7f10cca88dc1c4f643598" }
+blockbuster = "0.9.0-beta.1"
 figment = { version = "0.10.6", features = ["env", "toml", "yaml"] }
 cadence = "0.29.0"
 cadence-macros = "0.29.0"

--- a/prepare-local-docker-env.sh
+++ b/prepare-local-docker-env.sh
@@ -1,47 +1,71 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-CWD=$(pwd)
-mkdir programs
-mkdir metaplex_program_library || true
-curl -LkSs https://api.github.com/repos/metaplex-foundation/metaplex-program-library/tarball/update-deps | tar -xz --strip-components=1 -C ./metaplex_program_library
+# output colours
+RED() { echo $'\e[1;31m'$1$'\e[0m'; }
+GRN() { echo $'\e[1;32m'$1$'\e[0m'; }
 
-pushd metaplex_program_library/token-metadata/program
-  cargo build-bpf --bpf-out-dir ./here
-  mv ./here/mpl_token_metadata.so $CWD/programs/metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s.so
-popd
+CURRENT_DIR=$(pwd)
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+# go to parent folder
+cd $(dirname $(dirname $SCRIPT_DIR))
 
-pushd metaplex_program_library/bubblegum/program
-  cargo build-bpf --bpf-out-dir ./here
-  mv ./here/mpl_bubblegum.so $CWD/programs/BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY.so
-popd
+EXTERNAL_ID=("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s" \
+"BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY" \
+"cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK" \
+"noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV" \
+"ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL" \
+"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA" \
+"TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb" \
+)
+EXTERNAL_SO=("metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s.so" \
+"BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY.so" \
+"cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK.so" \
+"noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV.so"
+"ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL.so" \
+"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA.so" \
+"TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb.so" \
+)
 
-mkdir solana_program_library || true
-curl -LkSs https://api.github.com/repos/solana-labs/solana-program-library/tarball/token-swap-js-v0.4.0 | tar -xz --strip-components=1 -C ./solana_program_library
-tar -zxf -C /solana_program_library solana-program-library.tar.gz
-pushd solana_program_library/account-compression/programs/account-compression
-  cargo build-bpf --bpf-out-dir ./here
-  mv ./here/spl_account_compression.so $CWD/programs/cmtDvXumGCrqC1Age74AVPhSRVXJMd8PJS91L8KbNCK.so
-popd
+if [ -z ${RPC+x} ]; then
+    RPC="https://api.mainnet-beta.solana.com"
+fi
 
-pushd solana_program_library/account-compression/programs/noop
-  cargo build-bpf --bpf-out-dir ./here
-  mv ./here/spl_noop.so $CWD/programs/noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV.so
-popd
+if [ -z "$OUTPUT" ]; then
+    OUTPUT=$CURRENT_DIR/programs
+fi
 
-pushd solana_program_library/associated-token-account/program
-  cargo build-bpf --bpf-out-dir ./here
-  mv ./here/spl_associated_token_account.so $CWD/programs/ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL.so
-popd
+# creates the output directory if it doesn't exist
+if [ ! -d ${OUTPUT} ]; then
+    mkdir ${OUTPUT}
+fi
 
-pushd solana_program_library/token/program
-  cargo build-bpf --bpf-out-dir ./here
-  mv ./here/spl_token.so $CWD/programs/TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA.so
-popd
+# only prints this if we have external programs
+if [ ${#EXTERNAL_ID[@]} -gt 0 ]; then
+    echo "Dumping external programs to: '${OUTPUT}'"
+fi
 
-pushd solana_program_library/token/program-2022
-  cargo build-bpf --bpf-out-dir ./here
-  mv ./here/spl_token_2022.so $CWD/programs/TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb.so
-popd
+# dump external programs binaries if needed
+for i in ${!EXTERNAL_ID[@]}; do
+    if [ ! -f "${OUTPUT}/${EXTERNAL_SO[$i]}" ]; then
+        solana program dump -u $RPC ${EXTERNAL_ID[$i]} ${OUTPUT}/${EXTERNAL_SO[$i]}
+    else
+        solana program dump -u $RPC ${EXTERNAL_ID[$i]} ${OUTPUT}/onchain-${EXTERNAL_SO[$i]} > /dev/null
+        ON_CHAIN=`sha256sum -b ${OUTPUT}/onchain-${EXTERNAL_SO[$i]} | cut -d ' ' -f 1`
+        LOCAL=`sha256sum -b ${OUTPUT}/${EXTERNAL_SO[$i]} | cut -d ' ' -f 1`
 
-rm -rf solana_program_library
-rm -rf metaplex_program_library
+        if [ "$ON_CHAIN" != "$LOCAL" ]; then
+            echo $(RED "[ WARNING ] on-chain and local binaries are different for '${EXTERNAL_SO[$i]}'")
+        else
+            echo "$(GRN "[ SKIPPED ]") on-chain and local binaries are the same for '${EXTERNAL_SO[$i]}'"
+        fi
+
+        rm ${OUTPUT}/onchain-${EXTERNAL_SO[$i]}
+    fi
+done
+
+# only prints this if we have external programs
+if [ ${#EXTERNAL_ID[@]} -gt 0 ]; then
+    echo ""
+fi
+
+cd ${CURRENT_DIR}

--- a/tools/fetch_trees/Cargo.toml
+++ b/tools/fetch_trees/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1.0.70"
 async-trait = "0.1.53"
 borsh = "~0.10.3"
 clap = { version = "4.2.2", features = ["derive", "cargo"] }
-mpl-bubblegum = "1.0.1-beta.2"
+mpl-bubblegum = "1.0.1-beta.3"
 solana-account-decoder = "~1.16.16"
 solana-client = "~1.16.16"
 solana-sdk = "~1.16.16"


### PR DESCRIPTION
### Notes
* Update `prepare-local-docker-env` script to download programs from mainnet rather than build locally from a downloaded tag.
* Update test validator image in docker compose file.
* Update blockbuster to use a beta release from the blockbuster `update-metadata-staging` branch.
* Also update to latest Bubblegum beta release which is what the blockbuster release uses.

### Testing
Tested a clean build and observed it can build and run in docker, and NFTs will be periodically minted.
```
./prepare-local-docker-env.sh
docker compose up --force-recreate --build
```
