### PR TITLE
Remove early return if uri is empty

### DIFF
--- a/nft_ingester/src/program_transformers/bubblegum/mint_v1.rs
+++ b/nft_ingester/src/program_transformers/bubblegum/mint_v1.rs
@@ -85,11 +85,7 @@ where
                     true => ChainMutability::Mutable,
                     false => ChainMutability::Immutable,
                 };
-                if uri.is_empty() {
-                    return Err(IngesterError::DeserializationError(
-                        "URI is empty".to_string(),
-                    ));
-                }
+
                 let data = asset_data::ActiveModel {
                     id: Set(id_bytes.to_vec()),
                     chain_data_mutability: Set(chain_mutability),


### PR DESCRIPTION
In a previous PR we allow URI to be empty and not create a background task, but we need to remove this early return otherwise it will still return early.

(It is already removed in the helius-labs version from which the previous PR's change was upstreamed)
