### PR TITLE
Update raw name and raw symbol for existing NFTs

### DIFF
--- a/nft_ingester/src/program_transformers/bubblegum/mint_v1.rs
+++ b/nft_ingester/src/program_transformers/bubblegum/mint_v1.rs
@@ -110,6 +110,8 @@ where
                                 asset_data::Column::MetadataMutability,
                                 asset_data::Column::SlotUpdated,
                                 asset_data::Column::Reindex,
+                                asset_data::Column::RawName,
+                                asset_data::Column::RawSymbol,
                             ])
                             .to_owned(),
                     )

--- a/nft_ingester/src/program_transformers/token_metadata/v1_asset.rs
+++ b/nft_ingester/src/program_transformers/token_metadata/v1_asset.rs
@@ -161,6 +161,8 @@ pub async fn save_v1_asset<T: ConnectionTrait + TransactionTrait>(
                     asset_data::Column::MetadataMutability,
                     asset_data::Column::SlotUpdated,
                     asset_data::Column::Reindex,
+                    asset_data::Column::RawName,
+                    asset_data::Column::RawSymbol,
                 ])
                 .to_owned(),
         )


### PR DESCRIPTION
Update the raw name and raw symbol from the onchain data for existing NFTs when reingesting. This allows correction of incorrect values during reprocessing on an existing index.
