### PR TITLE
Configurable account streams

### DIFF
--- a/nft_ingester/src/database.rs
+++ b/nft_ingester/src/database.rs
@@ -8,8 +8,8 @@ const DEFAULT_MAX: u32 = 125;
 pub async fn setup_database(config: IngesterConfig) -> PgPool {
     let max = config.max_postgres_connections.unwrap_or(DEFAULT_MAX);
     if config.role == Some(IngesterRole::All) || config.role == Some(IngesterRole::Ingester) {
-        let relative_max =
-            config.get_account_stream_worker_count() + config.get_transaction_stream_worker_count();
+        let relative_max: u32 =
+            config.get_worker_config().iter().map(|c| c.worker_count).sum();
         let should_be_at_least = relative_max * 5;
         if should_be_at_least > max {
             panic!("Please increase max_postgres_connections to at least {}, at least 5 connections per worker process should be given", should_be_at_least);

--- a/nft_ingester/src/main.rs
+++ b/nft_ingester/src/main.rs
@@ -105,12 +105,12 @@ pub async fn main() -> Result<(), IngesterError> {
 
         // iterate all the workers
         for worker in workers {
-            let stream_name = worker.stream_name.to_owned().as_str();
+            let stream_name = Box::leak(Box::new(worker.stream_name.to_owned()));
 
             let mut timer_worker = StreamSizeTimer::new(
                 stream_metrics_timer,
                 config.messenger_config.clone(),
-                stream_name.clone(),
+                stream_name.as_str(),
             )?;
 
             if let Some(t) = timer_worker.start::<RedisMessenger>().await {


### PR DESCRIPTION
This makes the worker configuration more dynamic, by letting you specify custom streams in the config file. It also removes an unnecessary dependency between plerkle_messenger and the ingester in pulling the names of the stream from plerkle messenger.

The default behaviour of the ingester stays the same, creating 2 workers for TXN and 2 workers for ACC streams by default. 