### PR TITLE
Improvements for NFT indexing and query consistency

### DIFF
--- a/das_api/src/error.rs
+++ b/das_api/src/error.rs
@@ -29,7 +29,7 @@ pub enum DasApiError {
     PaginationExceededError,
     #[error("Cursor Validation Err: {0} is invalid")]
     CursorValidationError(String),
-    #[error("Pagination Sorting Error. Only sorting based on id is support for this pagination")]
+    #[error("Pagination Sorting Error. Only sorting based on id is supported for this pagination option.")]
     PaginationSortingValidationError,
 }
 

--- a/digital_asset_types/src/dao/mod.rs
+++ b/digital_asset_types/src/dao/mod.rs
@@ -73,78 +73,12 @@ pub struct SearchAssetsQuery {
 }
 
 impl SearchAssetsQuery {
-    pub const fn count_conditions(&self) -> usize {
-        // Initialize counter
-        let mut num_conditions = 0;
-        if self.specification_version.is_some() {
-            num_conditions += 1;
-        }
-        if self.specification_asset_class.is_some() {
-            num_conditions += 1;
-        }
-        if self.owner_address.is_some() {
-            num_conditions += 1;
-        }
-        if self.owner_type.is_some() {
-            num_conditions += 1;
-        }
-        if self.delegate.is_some() {
-            num_conditions += 1;
-        }
-        if self.frozen.is_some() {
-            num_conditions += 1;
-        }
-        if self.supply.is_some() {
-            num_conditions += 1;
-        }
-        if self.supply_mint.is_some() {
-            num_conditions += 1;
-        }
-        if self.compressed.is_some() {
-            num_conditions += 1;
-        }
-        if self.compressible.is_some() {
-            num_conditions += 1;
-        }
-        if self.royalty_target_type.is_some() {
-            num_conditions += 1;
-        }
-        if self.royalty_target.is_some() {
-            num_conditions += 1;
-        }
-        if self.royalty_amount.is_some() {
-            num_conditions += 1;
-        }
-        if self.burnt.is_some() {
-            num_conditions += 1;
-        }
-        if self.creator_address.is_some() {
-            num_conditions += 1;
-        }
-        if self.creator_address.is_some() {
-            num_conditions += 1;
-        }
-        if self.grouping.is_some() {
-            num_conditions += 1;
-        }
-        if self.json_uri.is_some() {
-            num_conditions += 1;
-        }
-        if self.name.is_some() {
-            num_conditions += 1;
-        }
-
-        num_conditions
-    }
-
     pub fn conditions(&self) -> Result<(Condition, Vec<RelationDef>), DbErr> {
         let mut conditions = match self.condition_type {
             // None --> default to all when no option is provided
             None | Some(ConditionType::All) => Condition::all(),
             Some(ConditionType::Any) => Condition::any(),
         };
-
-        let mut joins = Vec::new();
 
         conditions = conditions
             .add_option(
@@ -163,17 +97,11 @@ impl SearchAssetsQuery {
                     .map(|x| asset::Column::Owner.eq(x)),
             )
             .add_option(
-                self.owner_type
-                    .clone()
-                    .map(|x| asset::Column::OwnerType.eq(x)),
-            )
-            .add_option(
                 self.delegate
                     .to_owned()
                     .map(|x| asset::Column::Delegate.eq(x)),
             )
             .add_option(self.frozen.map(|x| asset::Column::Frozen.eq(x)))
-            .add_option(self.supply.map(|x| asset::Column::Supply.eq(x)))
             .add_option(
                 self.supply_mint
                     .to_owned()
@@ -197,6 +125,36 @@ impl SearchAssetsQuery {
             )
             .add_option(self.burnt.map(|x| asset::Column::Burnt.eq(x)));
 
+        if let Some(s) = self.supply {
+            conditions = conditions.add(asset::Column::Supply.eq(s));
+        } else {
+            // By default, we ignore malformed tokens by ignoring tokens with supply=0
+            // unless they are burnt.
+            //
+            // cNFTs keep supply=1 after they are burnt.
+            // Regular NFTs go to supply=0 after they are burnt.
+            conditions = conditions.add(
+                asset::Column::Supply
+                    .ne(0)
+                    .or(asset::Column::Burnt.eq(true)),
+            )
+        }
+
+        if let Some(o) = self.owner_type.clone() {
+            conditions = conditions.add(asset::Column::OwnerType.eq(o));
+        } else {
+            // Default to NFTs
+            //
+            // In theory, the owner_type=single check should be sufficient,
+            // however there is an old bug that has marked some non-NFTs as "single" with supply > 1.
+            // The supply check guarentees we do not include those.
+            conditions = conditions.add_option(Some(
+                asset::Column::OwnerType
+                    .eq(OwnerType::Single)
+                    .and(asset::Column::Supply.lte(1)),
+            ));
+        }
+
         if let Some(c) = self.creator_address.to_owned() {
             conditions = conditions.add(asset_creators::Column::Creator.eq(c));
         }
@@ -208,6 +166,7 @@ impl SearchAssetsQuery {
         }
 
         // If creator_address or creator_verified is set, join with asset_creators
+        let mut joins = Vec::new();
         if self.creator_address.is_some() || self.creator_verified.is_some() {
             let rel = asset_creators::Relation::Asset
                 .def()

--- a/digital_asset_types/src/rpc/filter.rs
+++ b/digital_asset_types/src/rpc/filter.rs
@@ -11,7 +11,7 @@ pub struct AssetSorting {
 impl Default for AssetSorting {
     fn default() -> AssetSorting {
         AssetSorting {
-            sort_by: AssetSortBy::Created,
+            sort_by: AssetSortBy::Id,
             sort_direction: Some(AssetSortDirection::default()),
         }
     }

--- a/nft_ingester/src/program_transformers/token/mod.rs
+++ b/nft_ingester/src/program_transformers/token/mod.rs
@@ -1,6 +1,6 @@
 use crate::{error::IngesterError, tasks::TaskData};
 use blockbuster::programs::token_account::TokenProgramAccount;
-use digital_asset_types::dao::{asset, token_accounts, tokens};
+use digital_asset_types::dao::{asset, sea_orm_active_enums::OwnerType, token_accounts, tokens};
 use plerkle_serialization::AccountInfo;
 use sea_orm::{
     entity::*, query::*, sea_query::OnConflict, ActiveValue::Set, ConnectionTrait,
@@ -121,20 +121,38 @@ pub async fn handle_token_program_account<'a, 'b, 'c>(
                 )
                 .build(DbBackend::Postgres);
             query.sql = format!(
-                "{} WHERE excluded.slot_updated > tokens.slot_updated",
+                "{} WHERE excluded.slot_updated >= tokens.slot_updated",
                 query.sql
             );
             db.execute(query).await?;
+
             let asset_update: Option<asset::Model> = asset::Entity::find_by_id(key_bytes.clone())
-                .filter(asset::Column::OwnerType.eq("single"))
+                .filter(
+                    asset::Column::OwnerType
+                        .eq(OwnerType::Single)
+                        .or(asset::Column::OwnerType
+                            .eq(OwnerType::Unknown)
+                            .and(asset::Column::Supply.eq(1))),
+                )
                 .one(db)
                 .await?;
             if let Some(asset) = asset_update {
-                let mut active: asset::ActiveModel = asset.into();
+                let mut active: asset::ActiveModel = asset.clone().into();
                 active.supply = Set(m.supply as i64);
                 active.supply_mint = Set(Some(key_bytes));
+
+                // Update owner_type based on the supply.
+                if asset.owner_type == OwnerType::Unknown {
+                    active.owner_type = match m.supply.cmp(&1) {
+                        std::cmp::Ordering::Equal => Set(OwnerType::Single),
+                        std::cmp::Ordering::Greater => Set(OwnerType::Token),
+                        _ => NotSet,
+                    }
+                }
+
                 active.save(db).await?;
             }
+
             Ok(())
         }
         _ => Err(IngesterError::NotImplemented),

--- a/nft_ingester/src/program_transformers/token_metadata/mod.rs
+++ b/nft_ingester/src/program_transformers/token_metadata/mod.rs
@@ -33,7 +33,7 @@ pub async fn handle_token_metadata_account<'a, 'b, 'c>(
             Ok(())
         }
         TokenMetadataAccountData::MetadataV1(m) => {
-            let task = save_v1_asset(db, m.mint.as_ref().into(), account_update.slot(), m).await?;
+            let task = save_v1_asset(db, m, account_update.slot()).await?;
             if let Some(task) = task {
                 task_manager.send(task)?;
             }


### PR DESCRIPTION
## Overview
* Indexing improvements for regular NFTs.
    * Fix parsing for ownership types based on token standard. 
    *  If a token standard is unknown, but supply=1, then mark it as an NFT. If supply > 1, mark it as fungible.
    * In v1_asset, retry the fetch for a mint/token account since all accounts can arrive at once during an NFT mint.
 * Query only well-formed tokens by default w/ search assets (like getAssetsByOwner). Only query NFTs, since only NFTs are supported at the moment. These changes avoid inconsistencies in the responses that confused our customers.
    * TLDR: Your queries only include well-defined NFTs unless you configure flags like supply/owner_type yourself (no one really does).

## Testing
These changes are running in Helius production, but I also ran the code locally and spot checked against regular NFTs.