### PR TITLE
Remove asset_creator_unique as we now allow duplicate rows

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -32,6 +32,7 @@ mod m20230918_182123_add_raw_name_symbol;
 mod m20230919_072154_cl_audits;
 mod m20231019_120101_add_seq_numbers_bgum_update_metadata;
 mod m20231206_120101_remove_was_decompressed;
+mod m20240117_120101_remove_creator_asset_unique_index;
 
 pub struct Migrator;
 
@@ -71,6 +72,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230919_072154_cl_audits::Migration),
             Box::new(m20231019_120101_add_seq_numbers_bgum_update_metadata::Migration),
             Box::new(m20231206_120101_remove_was_decompressed::Migration),
+            Box::new(m20240117_120101_remove_creator_asset_unique_index::Migration),
         ]
     }
 }

--- a/migration/src/m20240117_120101_remove_creator_asset_unique_index.rs
+++ b/migration/src/m20240117_120101_remove_creator_asset_unique_index.rs
@@ -1,0 +1,35 @@
+use digital_asset_types::dao::asset_creators;
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                sea_query::Index::drop()
+                    .name("asset_creator_unique")
+                    .table(asset_creators::Entity)
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_index(
+                Index::create()
+                    .unique()
+                    .name("asset_creator_unique")
+                    .col(asset_creators::Column::AssetId)
+                    .col(asset_creators::Column::Creator)
+                    .table(asset_creators::Entity)
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Notes
* We now allow for duplicates because we allow for stale rows, but if there is a duplicate @NicolasPennie found it will not index due to a contraint.  Detected by Helius metrics dropping updates on regular NFTs.
* Same issue exists for both cNFT and regular NFTs.
* If we remove the constraint it works again.

### Testing
**Tested with "Improve workspace usage (#141)" (c572af9208ecfebdde120d15c5b45b5e6568ae10) reverted, because the new workspace stuff is causing issue with docker build that needs to be fixed.  I don't think it should change the outcome at all of this testing since it is not related.**

* Ran with Bubblegum using devnet txs:
  * Create and mint to tree with 3 creators:
     * 2DP84v6Pi3e4v5i7KSvzmK4Ufbzof3TAiEqDbm9gg8jZpBRF9f1Cy6x54kvZoHPX9k1XfqbsG1FTv2KVP9fvNrN6
  * Update metadata to have only two creators, with previous third creator being moved to second creator position, and thus creating a duplicate creator row in `asset_creators`:
    * 3bsL5zmLKvhN9Je4snTKxjFSpmXEEg2cvMHm2rCNgaEYkNXBqJTA4N7QmvBSWPiNUQPtzJSYzpQYX92NowV3L7vN

* See expected results in `asset_creators` table before an after the `update_metadata`.
* `curl` commands below run successfully.
  * Before the update all three creators are listed by `getAsset`, and all three `getAssetsByCreator` calls below return the asset.
   * After the update metadata, as expected, only the first and third creators are listed by `getAsset`, and only the first and third `getAssetsByCreator` return the asset.
```
curl --request POST --url 'http://localhost:9090' --header 'Content-Type: application/json' --data '{
    "jsonrpc": "2.0",
    "method": "getAsset",
    "params": [
      "FLFoCw2RBbxiw9rbEeqPWJ5rasArD9kTCKWEJirTexsU"
    ],
    "id": 0
}' | json_pp

// first creator
curl --request POST --url 'http://localhost:9090'  --header 'Content-Type: application/json' --data '{
  "jsonrpc": "2.0",
  "id": 0,
  "method": "getAssetsByCreator",
  "params": {
    "creatorAddress": "Fq4HDXfutKjEZ7zZP2JmKboSm2ZsYsKEJ7BLQAfrpNcc",
    "page": 1,
    "limit": 50,
    "sortBy": {
      "sortBy": "created",
      "sortDirection": "asc"
    }
  }
}' | json_pp

// second creator
curl --request POST --url 'http://localhost:9090'  --header 'Content-Type: application/json' --data '{
  "jsonrpc": "2.0",
  "id": 0,
  "method": "getAssetsByCreator",
  "params": {
    "creatorAddress": "5EzkzhGFwiPQgwa5gv4VJxsu1oTBjb1YnWASSjtkG72K",
    "page": 1,
    "limit": 50,
    "sortBy": {
      "sortBy": "created",
      "sortDirection": "asc"
    }
  }
}' | json_pp

// third creator
curl --request POST --url 'http://localhost:9090'  --header 'Content-Type: application/json' --data '{
  "jsonrpc": "2.0",
  "id": 0,
  "method": "getAssetsByCreator",
  "params": {
    "creatorAddress": "3Le8mq2Y7kpAwAKmTRyr7n6vcM9hdDuxmiWA3tUYi4Nw",
    "page": 1,
    "limit": 50,
    "sortBy": {
      "sortBy": "created",
      "sortDirection": "asc"
    }
  }
}' | json_pp
```