### PR TITLE
[Feat] Ops cli with tree backfiller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,6 +824,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backon"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a6197b2120bb2185a267f6515038558b019e92b832bb0320e96d66268dcf9"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,6 +1675,67 @@ dependencies = [
  "darling_core",
  "quote 1.0.33",
  "syn 2.0.38",
+]
+
+[[package]]
+name = "das-core"
+version = "0.7.2"
+dependencies = [
+ "anyhow",
+ "cadence",
+ "cadence-macros",
+ "clap 4.4.8",
+ "sqlx",
+]
+
+[[package]]
+name = "das-ops"
+version = "0.7.2"
+dependencies = [
+ "anchor-client",
+ "anchor-lang",
+ "anyhow",
+ "backon",
+ "base64 0.21.4",
+ "borsh 0.10.3",
+ "bs58 0.4.0",
+ "cadence",
+ "cadence-macros",
+ "chrono",
+ "clap 4.4.8",
+ "das-core",
+ "digital_asset_types",
+ "env_logger 0.10.0",
+ "figment",
+ "flatbuffers",
+ "futures",
+ "futures-util",
+ "indicatif",
+ "lazy_static",
+ "log",
+ "mpl-bubblegum",
+ "plerkle_messenger",
+ "plerkle_serialization",
+ "redis",
+ "regex",
+ "reqwest",
+ "rust-crypto",
+ "sea-orm",
+ "sea-query 0.28.5",
+ "serde",
+ "serde_json",
+ "solana-account-decoder",
+ "solana-client",
+ "solana-sdk",
+ "solana-transaction-status",
+ "spl-account-compression",
+ "spl-concurrent-merkle-tree",
+ "sqlx",
+ "thiserror",
+ "tokio",
+ "tokio-postgres",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -3893,6 +3966,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+dependencies = [
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,12 @@
 [workspace]
 members = [
+  "core",
   "das_api",
   "digital_asset_types",
   "metaplex-rpc-proxy",
   "migration",
   "nft_ingester",
+  "ops",
   "tools/acc_forwarder",
   "tools/bgtask_creator",
   "tools/fetch_trees",
@@ -36,8 +38,9 @@ cadence = "0.29.0"
 cadence-macros = "0.29.0"
 chrono = "0.4.19"
 clap = "4.2.2"
-das_api = {path = "das_api"}
-digital_asset_types = {path = "digital_asset_types"}
+das_api = { path = "das_api" }
+das-core = { path = "core" }
+digital_asset_types = { path = "digital_asset_types" }
 enum-iterator = "1.2.0"
 enum-iterator-derive = "1.1.0"
 env_logger = "0.10.0"
@@ -50,7 +53,7 @@ futures-util = "0.3.27"
 hex = "0.4.3"
 hyper = "0.14.23"
 indexmap = "1.9.3"
-insta = {version = "1.34.0", features = ["json"]}
+insta = { version = "1.34.0", features = ["json"] }
 itertools = "0.10.1"
 jsonpath_lib = "0.3.0"
 jsonrpsee = "0.16.2"
@@ -58,13 +61,13 @@ jsonrpsee-core = "0.16.2"
 lazy_static = "1.4.0"
 log = "0.4.17"
 metrics = "0.20.1"
-migration = {path = "migration"}
+migration = { path = "migration" }
 mime_guess = "2.0.4"
 mpl-bubblegum = "1.2.0"
 mpl-token-metadata = "4.1.1"
-nft_ingester = {path = "nft_ingester"}
+nft_ingester = { path = "nft_ingester" }
 num-derive = "0.3.3"
-num-integer = {version = "0.1.44", default_features = false}
+num-integer = { version = "0.1.44", default_features = false }
 num-traits = "0.2.15"
 once_cell = "1.19.0"
 open-rpc-derive = "0.0.4"
@@ -80,13 +83,13 @@ reqwest = "0.11.13"
 rust-crypto = "0.2.36"
 schemars = "0.8.6"
 schemars_derive = "0.8.6"
-sea-orm = {version = "0.10.6", features = [
+sea-orm = { version = "0.10.6", features = [
   "macros",
   "runtime-tokio-rustls",
   "sqlx-postgres",
   "with-chrono",
   "mock",
-]}
+] }
 sea-orm-migration = "0.10.6"
 sea-query = "0.28.1"
 serde = "1.0.137"
@@ -103,25 +106,25 @@ spl-account-compression = "0.2.0"
 spl-associated-token-account = ">= 1.1.3, < 3.0"
 spl-concurrent-merkle-tree = "0.2.0"
 spl-noop = "0.2.0"
-spl-token = {version = ">= 3.5.0, < 5.0", features = ["no-entrypoint"]}
-sqlx = {version = "0.6.2", features = [
+spl-token = { version = ">= 3.5.0, < 5.0", features = ["no-entrypoint"] }
+sqlx = { version = "0.6.2", features = [
   "macros",
   "runtime-tokio-rustls",
   "postgres",
   "uuid",
   "offline",
   "json",
-]}
+] }
 stretto = "0.7.2"
 thiserror = "1.0.31"
-tokio = {version = "1.30.0", features = ["macros", "rt-multi-thread"]}
+tokio = { version = "1.30.0", features = ["macros", "rt-multi-thread"] }
 tokio-postgres = "0.7.7"
 tokio-stream = "0.1.14"
 tower = "0.4.13"
 tower-http = "0.3.5"
 tracing = "0.1.35"
 tracing-subscriber = "0.3.16"
-txn_forwarder = {path = "tools/txn_forwarder"}
+txn_forwarder = { path = "tools/txn_forwarder" }
 url = "2.3.1"
 uuid = "1.0.0"
 wasi = "0.7.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "das-core"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+clap = { workspace = true }
+anyhow = { workspace = true }
+sqlx = { workspace = true }
+cadence = { workspace = true }
+cadence-macros = { workspace = true }
+
+[lints]
+workspace = true

--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -1,0 +1,38 @@
+use anyhow::Result;
+use clap::Parser;
+use sqlx::{
+    postgres::{PgConnectOptions, PgPoolOptions},
+    PgPool,
+};
+
+#[derive(Debug, Parser, Clone)]
+pub struct PoolArgs {
+    /// The database URL.
+    #[arg(long, env)]
+    pub database_url: String,
+    /// The maximum number of connections to the database.
+    #[arg(long, env, default_value = "125")]
+    pub database_max_connections: u32,
+    /// The minimum number of connections to the database.
+    #[arg(long, env, default_value = "5")]
+    pub database_min_connections: u32,
+}
+
+///// Establishes a connection to the database using the provided configuration.
+/////
+///// # Arguments
+/////
+///// * `config` - A `PoolArgs` struct containing the database URL and the minimum and maximum number of connections.
+/////
+///// # Returns
+/////
+///// * `Result<DatabaseConnection, DbErr>` - On success, returns a `DatabaseConnection`. On failure, returns a `DbErr`.
+pub async fn connect_db(config: PoolArgs) -> Result<PgPool, sqlx::Error> {
+    let options: PgConnectOptions = config.database_url.parse()?;
+
+    PgPoolOptions::new()
+        .min_connections(config.database_min_connections)
+        .max_connections(config.database_max_connections)
+        .connect_with(options)
+        .await
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,0 +1,5 @@
+mod db;
+mod metrics;
+
+pub use db::*;
+pub use metrics::*;

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -1,0 +1,31 @@
+use anyhow::Result;
+use cadence::{BufferedUdpMetricSink, QueuingMetricSink, StatsdClient};
+use cadence_macros::set_global_default;
+use clap::Parser;
+use std::net::UdpSocket;
+
+#[derive(Clone, Parser, Debug)]
+pub struct MetricsArgs {
+    #[arg(long, env, default_value = "127.0.0.1")]
+    pub metrics_host: String,
+    #[arg(long, env, default_value = "8125")]
+    pub metrics_port: u16,
+    #[arg(long, env, default_value = "das.backfiller")]
+    pub metrics_prefix: String,
+}
+
+pub fn setup_metrics(config: MetricsArgs) -> Result<()> {
+    let host = (config.metrics_host, config.metrics_port);
+
+    let socket = UdpSocket::bind("0.0.0.0:0")?;
+    socket.set_nonblocking(true)?;
+
+    let udp_sink = BufferedUdpMetricSink::from(host, socket)?;
+    let queuing_sink = QueuingMetricSink::from(udp_sink);
+
+    let client = StatsdClient::from_sink(&config.metrics_prefix, queuing_sink);
+
+    set_global_default(client);
+
+    Ok(())
+}

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -36,6 +36,7 @@ mod m20240104_203133_add_cl_audits_v2;
 mod m20240104_203328_remove_cl_audits;
 mod m20240116_130744_add_update_metadata_ix;
 mod m20240117_120101_alter_creator_indices;
+mod m20240124_173104_add_tree_seq_index_to_cl_audits_v2;
 
 pub mod model;
 
@@ -81,6 +82,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20240104_203328_remove_cl_audits::Migration),
             Box::new(m20240116_130744_add_update_metadata_ix::Migration),
             Box::new(m20240117_120101_alter_creator_indices::Migration),
+            Box::new(m20240124_173104_add_tree_seq_index_to_cl_audits_v2::Migration),
         ]
     }
 }

--- a/migration/src/m20240124_173104_add_tree_seq_index_to_cl_audits_v2.rs
+++ b/migration/src/m20240124_173104_add_tree_seq_index_to_cl_audits_v2.rs
@@ -1,0 +1,35 @@
+use super::model::table::ClAuditsV2;
+use sea_orm::{ConnectionTrait, DatabaseBackend, Statement};
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+
+        conn.execute(Statement::from_string(
+            DatabaseBackend::Postgres,
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS tree_seq_idx ON cl_audits_v2 (tree, seq);"
+                .to_string(),
+        ))
+        .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("tree_seq_idx")
+                    .table(ClAuditsV2::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/ops/Cargo.toml
+++ b/ops/Cargo.toml
@@ -1,0 +1,56 @@
+[package]
+name = "das-ops"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+publish.workspace = true
+
+[[bin]]
+name = "das-ops"
+
+[dependencies]
+
+clap = { workspace = true, features = ["derive", "cargo", "env"] }
+das-core = { workspace = true }
+backon = "0.4.1"
+log = { workspace = true }
+env_logger = { workspace = true }
+anyhow = { workspace = true }
+redis = { workspace = true }
+futures = { workspace = true }
+futures-util = { workspace = true }
+base64 = { workspace = true }
+indicatif = "0.17.5"
+thiserror = { workspace = true }
+serde_json = { workspace = true }
+cadence = { workspace = true }
+cadence-macros = { workspace = true }
+anchor-client = { workspace = true }
+tokio = { workspace = true }
+sqlx = { workspace = true }
+sea-orm = { workspace = true }
+sea-query = { workspace = true }
+chrono = { workspace = true }
+tokio-postgres = { workspace = true }
+serde = { workspace = true }
+bs58 = { workspace = true }
+reqwest = { workspace = true }
+plerkle_messenger = { workspace = true }
+plerkle_serialization = { workspace = true }
+flatbuffers = { workspace = true }
+lazy_static = { workspace = true }
+regex = { workspace = true }
+digital_asset_types = { workspace = true }
+mpl-bubblegum = { workspace = true }
+spl-account-compression = { workspace = true }
+spl-concurrent-merkle-tree = { workspace = true }
+uuid = { workspace = true }
+figment = { workspace = true }
+solana-sdk = { workspace = true }
+solana-client = { workspace = true }
+solana-transaction-status = { workspace = true }
+solana-account-decoder = { workspace = true }
+rust-crypto = { workspace = true }
+url = { workspace = true }
+anchor-lang = { workspace = true }
+borsh = { workspace = true }

--- a/ops/src/bubblegum/README.md
+++ b/ops/src/bubblegum/README.md
@@ -1,0 +1,86 @@
+# Bubblegum
+
+The bubblegum CLI assists in detecting and indexing missing updates for compression trees that are managed by the MPL bubblegum program.
+
+## Commands
+
+Command line arguments can also be set through environment variables.
+
+### Backfill
+
+The `backfill` command initiates the crawling and backfilling process. It requires the Solana RPC URL, the database URL, and the messenger Redis URL.
+
+**warning**: The command expects full archive access to transactions. Before proceeding ensure your RPC is able to serve complete transaction history for Solana.  
+
+```mermaid
+flowchart
+    start((Start)) -->init[Initialize RPC, DB]
+    init --> fetchTreesDB[Fetch Trees from DB]
+    fetchTreesDB --> findGapsDB[Find Gaps in DB]
+    findGapsDB --> enqueueGapFills[Enqueue Gap Fills]
+    enqueueGapFills --> gapWorkerManager[Gap Worker Manager]
+    gapWorkerManager --> crawlSignatures[Crawl Solana RPC]
+    crawlSignatures --> enqueueSignatures[Enqueue Signatures]
+    enqueueSignatures --> transactionWorkerManager[Transaction Worker Manager]
+    transactionWorkerManager --> fetchTransactionsRPC[Fetch Transactions RPC]
+    fetchTransactionsRPC --> processTransactions[Push Transaction to Messenger]
+    processTransactions ---> Finished
+```
+
+```
+Usage: das-ops bubblegum backfill [OPTIONS] --database-url <DATABASE_URL> --messenger-redis-url <MESSENGER_REDIS_URL> --solana-rpc-url <SOLANA_RPC_URL>
+
+Options:
+      --tree-crawler-count <TREE_CRAWLER_COUNT>
+          Number of tree crawler workers [env: TREE_CRAWLER_COUNT=] [default: 20]
+      --signature-channel-size <SIGNATURE_CHANNEL_SIZE>
+          The size of the signature channel [env: SIGNATURE_CHANNEL_SIZE=] [default: 10000]
+      --gap-channel-size <GAP_CHANNEL_SIZE>
+          The size of the signature channel [env: GAP_CHANNEL_SIZE=] [default: 1000]
+      --transaction-worker-count <TRANSACTION_WORKER_COUNT>
+          The number of transaction workers [env: TRANSACTION_WORKER_COUNT=] [default: 100]
+      --gap-worker-count <GAP_WORKER_COUNT>
+          The number of gap workers [env: GAP_WORKER_COUNT=] [default: 25]
+      --only-trees <ONLY_TREES>
+          The list of trees to crawl. If not specified, all trees will be crawled [env: ONLY_TREES=]
+      --database-url <DATABASE_URL>
+          The database URL [env: DATABASE_URL=]
+      --database-max-connections <DATABASE_MAX_CONNECTIONS>
+          The maximum number of connections to the database [env: DATABASE_MAX_CONNECTIONS=] [default: 125]
+      --database-min-connections <DATABASE_MIN_CONNECTIONS>
+          The minimum number of connections to the database [env: DATABASE_MIN_CONNECTIONS=] [default: 5]
+      --messenger-redis-url <MESSENGER_REDIS_URL>
+          [env: MESSENGER_REDIS_URL=]
+      --messenger-redis-batch-size <MESSENGER_REDIS_BATCH_SIZE>
+          [env: MESSENGER_REDIS_BATCH_SIZE=] [default: 100]
+      --messenger-queue-connections <MESSENGER_QUEUE_CONNECTIONS>
+          [env: MESSENGER_QUEUE_CONNECTIONS=] [default: 25]
+      --messenger-queue-stream <MESSENGER_QUEUE_STREAM>
+          [env: MESSENGER_QUEUE_STREAM=] [default: TXNFILL]
+      --metrics-host <METRICS_HOST>
+          [env: METRICS_HOST=] [default: 127.0.0.1]
+      --metrics-port <METRICS_PORT>
+          [env: METRICS_PORT=] [default: 8125]
+      --metrics-prefix <METRICS_PREFIX>
+          [env: METRICS_PREFIX=] [default: das.backfiller]
+      --solana-rpc-url <SOLANA_RPC_URL>
+          [env: SOLANA_RPC_URL=]
+  -h, --help
+          Print help
+```
+
+### Metrics
+
+The bubblegum command provides several metrics for monitoring performance and status:
+
+Metric | Description
+--- | ---
+transaction.failed | Count of failed transaction
+transaction.succeeded | Count of successfully queued transaction
+transaction.queued | Time for a transaction to be queued
+gap.failed | Count of failed gap crawling
+gap.succeeded | Count of successfully crawled gaps
+gap.queued | Time for a gap to be queued
+tree.succeeded | Count of completed tree crawl
+tree.crawled | Time to crawl a tree
+job.completed | Time to complete the job

--- a/ops/src/bubblegum/backfiller.rs
+++ b/ops/src/bubblegum/backfiller.rs
@@ -1,0 +1,325 @@
+use super::{
+    queue::{QueueArgs, QueuePool},
+    rpc::{Rpc, SolanaRpcArgs},
+    tree::{TreeErrorKind, TreeGapFill, TreeGapModel, TreeResponse},
+};
+use anyhow::Result;
+use cadence_macros::{statsd_count, statsd_time};
+use clap::Parser;
+use das_core::{connect_db, setup_metrics, MetricsArgs, PoolArgs};
+use digital_asset_types::dao::cl_audits_v2;
+use flatbuffers::FlatBufferBuilder;
+use futures::{stream::FuturesUnordered, StreamExt};
+use indicatif::HumanDuration;
+use log::{error, info};
+use plerkle_serialization::serializer::seralize_encoded_transaction_with_status;
+use sea_orm::{
+    ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder, SqlxPostgresConnector,
+};
+use solana_sdk::signature::Signature;
+use std::time::Instant;
+use tokio::{sync::mpsc, task::JoinHandle};
+
+#[derive(Debug, Parser, Clone)]
+pub struct Args {
+    /// Number of tree crawler workers
+    #[arg(long, env, default_value = "20")]
+    pub tree_crawler_count: usize,
+
+    /// The size of the signature channel.
+    #[arg(long, env, default_value = "10000")]
+    pub signature_channel_size: usize,
+
+    /// The size of the signature channel.
+    #[arg(long, env, default_value = "1000")]
+    pub gap_channel_size: usize,
+
+    /// The number of transaction workers.
+    #[arg(long, env, default_value = "100")]
+    pub transaction_worker_count: usize,
+
+    /// The number of gap workers.
+    #[arg(long, env, default_value = "25")]
+    pub gap_worker_count: usize,
+
+    /// The list of trees to crawl. If not specified, all trees will be crawled.
+    #[arg(long, env, use_value_delimiter = true)]
+    pub only_trees: Option<Vec<String>>,
+
+    /// Database configuration
+    #[clap(flatten)]
+    pub database: PoolArgs,
+
+    /// Redis configuration
+    #[clap(flatten)]
+    pub queue: QueueArgs,
+
+    /// Metrics configuration
+    #[clap(flatten)]
+    pub metrics: MetricsArgs,
+
+    /// Solana configuration
+    #[clap(flatten)]
+    pub solana: SolanaRpcArgs,
+}
+
+/// Runs the backfilling process for the tree crawler.
+///
+/// This function initializes the necessary components for the backfilling process,
+/// including database connections, RPC clients, and worker managers for handling
+/// transactions and gaps. It then proceeds to fetch the trees that need to be crawled
+/// and manages the crawling process across multiple workers.
+///
+/// The function handles the following major tasks:
+/// - Establishing connections to the database and initializing RPC clients.
+/// - Setting up channels for communication between different parts of the system.
+/// - Spawning worker managers for processing transactions and gaps.
+/// - Fetching trees from the database and managing their crawling process.
+/// - Reporting metrics and logging information throughout the process.
+///
+/// # Arguments
+///
+/// * `config` - A configuration object containing settings for the backfilling process,
+///   including database, RPC, and worker configurations.
+///
+/// # Returns
+///
+/// This function returns a `Result` which is `Ok` if the backfilling process completes
+/// successfully, or an `Err` with an appropriate error message if any part of the process
+/// fails.
+///
+/// # Errors
+///
+/// This function can return errors related to database connectivity, RPC failures,
+/// or issues with spawning and managing worker tasks.
+pub async fn run(config: Args) -> Result<()> {
+    let pool = connect_db(config.database).await?;
+
+    let solana_rpc = Rpc::from_config(config.solana);
+    let transaction_solana_rpc = solana_rpc.clone();
+    let gap_solana_rpc = solana_rpc.clone();
+
+    setup_metrics(config.metrics)?;
+
+    let (sig_sender, mut sig_receiver) = mpsc::channel::<Signature>(config.signature_channel_size);
+    let gap_sig_sender = sig_sender.clone();
+    let (gap_sender, mut gap_receiver) = mpsc::channel::<TreeGapFill>(config.gap_channel_size);
+
+    let queue = QueuePool::try_from_config(config.queue).await?;
+
+    let transaction_worker_count = config.transaction_worker_count;
+
+    let transaction_worker_manager = tokio::spawn(async move {
+        let mut handlers = FuturesUnordered::new();
+
+        while let Some(signature) = sig_receiver.recv().await {
+            if handlers.len() >= transaction_worker_count {
+                handlers.next().await;
+            }
+
+            let solana_rpc = transaction_solana_rpc.clone();
+            let queue = queue.clone();
+
+            let handle = spawn_transaction_worker(solana_rpc, queue, signature);
+
+            handlers.push(handle);
+        }
+
+        futures::future::join_all(handlers).await;
+    });
+
+    let gap_worker_count = config.gap_worker_count;
+
+    let gap_worker_manager = tokio::spawn(async move {
+        let mut handlers = FuturesUnordered::new();
+
+        while let Some(gap) = gap_receiver.recv().await {
+            if handlers.len() >= gap_worker_count {
+                handlers.next().await;
+            }
+
+            let client = gap_solana_rpc.clone();
+            let sender = gap_sig_sender.clone();
+
+            let handle = spawn_crawl_worker(client, sender, gap);
+
+            handlers.push(handle);
+        }
+
+        futures::future::join_all(handlers).await;
+    });
+
+    let started = Instant::now();
+
+    let trees = if let Some(only_trees) = config.only_trees {
+        TreeResponse::find(&solana_rpc, only_trees).await?
+    } else {
+        TreeResponse::all(&solana_rpc).await?
+    };
+
+    let tree_count = trees.len();
+
+    info!(
+        "fetched {} trees in {}",
+        tree_count,
+        HumanDuration(started.elapsed())
+    );
+
+    let tree_crawler_count = config.tree_crawler_count;
+    let mut crawl_handles = FuturesUnordered::new();
+
+    for tree in trees {
+        if crawl_handles.len() >= tree_crawler_count {
+            crawl_handles.next().await;
+        }
+
+        let sender = gap_sender.clone();
+        let pool = pool.clone();
+        let conn = SqlxPostgresConnector::from_sqlx_postgres_pool(pool);
+
+        let handle = spawn_gap_worker(conn, sender, tree);
+
+        crawl_handles.push(handle);
+    }
+
+    futures::future::try_join_all(crawl_handles).await?;
+    drop(gap_sender);
+    info!("crawled all trees");
+
+    gap_worker_manager.await?;
+    drop(sig_sender);
+    info!("all gaps processed");
+
+    transaction_worker_manager.await?;
+    info!("all transactions queued");
+
+    statsd_time!("job.completed", started.elapsed());
+
+    info!(
+        "crawled {} trees in {}",
+        tree_count,
+        HumanDuration(started.elapsed())
+    );
+
+    Ok(())
+}
+
+fn spawn_gap_worker(
+    conn: DatabaseConnection,
+    sender: mpsc::Sender<TreeGapFill>,
+    tree: TreeResponse,
+) -> JoinHandle<Result<(), anyhow::Error>> {
+    tokio::spawn(async move {
+        let timing = Instant::now();
+
+        let mut gaps = TreeGapModel::find(&conn, tree.pubkey)
+            .await?
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let upper_known_seq = cl_audits_v2::Entity::find()
+            .filter(cl_audits_v2::Column::Tree.eq(tree.pubkey.as_ref().to_vec()))
+            .order_by_desc(cl_audits_v2::Column::Seq)
+            .one(&conn)
+            .await?;
+
+        let lower_known_seq = cl_audits_v2::Entity::find()
+            .filter(cl_audits_v2::Column::Tree.eq(tree.pubkey.as_ref().to_vec()))
+            .order_by_asc(cl_audits_v2::Column::Seq)
+            .one(&conn)
+            .await?;
+
+        if let Some(upper_seq) = upper_known_seq {
+            let signature = Signature::try_from(upper_seq.tx.as_ref())?;
+            info!(
+                "tree {} has known highest seq {} filling tree from {}",
+                tree.pubkey, upper_seq.seq, signature
+            );
+            gaps.push(TreeGapFill::new(tree.pubkey, None, Some(signature)));
+        } else if tree.seq > 0 {
+            info!(
+                "tree {} has no known highest seq but the actual seq is {} filling whole tree",
+                tree.pubkey, tree.seq
+            );
+            gaps.push(TreeGapFill::new(tree.pubkey, None, None));
+        }
+
+        if let Some(lower_seq) = lower_known_seq.filter(|seq| seq.seq > 1) {
+            let signature = Signature::try_from(lower_seq.tx.as_ref())?;
+
+            info!(
+                "tree {} has known lowest seq {} filling tree starting at {}",
+                tree.pubkey, lower_seq.seq, signature
+            );
+
+            gaps.push(TreeGapFill::new(tree.pubkey, Some(signature), None));
+        }
+
+        let gap_count = gaps.len();
+
+        for gap in gaps {
+            if let Err(e) = sender.send(gap).await {
+                statsd_count!("gap.failed", 1);
+                error!("send gap: {:?}", e);
+            }
+        }
+
+        info!("crawling tree {} with {} gaps", tree.pubkey, gap_count);
+
+        statsd_count!("tree.succeeded", 1);
+        statsd_time!("tree.crawled", timing.elapsed());
+
+        Ok::<(), anyhow::Error>(())
+    })
+}
+
+fn spawn_crawl_worker(
+    client: Rpc,
+    sender: mpsc::Sender<Signature>,
+    gap: TreeGapFill,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let timing = Instant::now();
+
+        if let Err(e) = gap.crawl(client, sender).await {
+            error!("tree transaction: {:?}", e);
+
+            statsd_count!("gap.failed", 1);
+        } else {
+            statsd_count!("gap.succeeded", 1);
+        }
+
+        statsd_time!("gap.queued", timing.elapsed());
+    })
+}
+
+async fn queue_transaction<'a>(
+    client: Rpc,
+    queue: QueuePool,
+    signature: Signature,
+) -> Result<(), TreeErrorKind> {
+    let transaction = client.get_transaction(&signature).await?;
+
+    let message = seralize_encoded_transaction_with_status(FlatBufferBuilder::new(), transaction)?;
+
+    queue.push(message.finished_data()).await?;
+
+    Ok(())
+}
+
+fn spawn_transaction_worker(client: Rpc, queue: QueuePool, signature: Signature) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let timing = Instant::now();
+
+        if let Err(e) = queue_transaction(client, queue, signature).await {
+            error!("queue transaction: {:?}", e);
+
+            statsd_count!("transaction.failed", 1);
+        } else {
+            statsd_count!("transaction.succeeded", 1);
+        }
+
+        statsd_time!("transaction.queued", timing.elapsed());
+    })
+}

--- a/ops/src/bubblegum/cmd.rs
+++ b/ops/src/bubblegum/cmd.rs
@@ -1,0 +1,27 @@
+use super::backfiller;
+use anyhow::Result;
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum Commands {
+    /// The 'backfill' command is used to cross-reference the index against on-chain accounts.
+    /// It crawls through trees and backfills any missed tree transactions.
+    #[clap(name = "backfill")]
+    Backfill(backfiller::Args),
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct BubblegumCommand {
+    #[clap(subcommand)]
+    pub action: Commands,
+}
+
+pub async fn subcommand(subcommand: BubblegumCommand) -> Result<()> {
+    match subcommand.action {
+        Commands::Backfill(args) => {
+            backfiller::run(args).await?;
+        }
+    }
+
+    Ok(())
+}

--- a/ops/src/bubblegum/mod.rs
+++ b/ops/src/bubblegum/mod.rs
@@ -1,0 +1,7 @@
+mod backfiller;
+mod cmd;
+mod queue;
+mod rpc;
+mod tree;
+
+pub use cmd::*;

--- a/ops/src/bubblegum/queue.rs
+++ b/ops/src/bubblegum/queue.rs
@@ -1,0 +1,103 @@
+use anyhow::Result;
+use clap::Parser;
+use figment::value::{Dict, Value};
+use plerkle_messenger::{Messenger, MessengerConfig, MessengerType};
+use std::num::TryFromIntError;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tokio::sync::{mpsc::error::TrySendError, Mutex};
+
+const TRANSACTION_BACKFILL_STREAM: &str = "TXNFILL";
+
+#[derive(Clone, Debug, Parser)]
+pub struct QueueArgs {
+    #[arg(long, env)]
+    pub messenger_redis_url: String,
+    #[arg(long, env, default_value = "100")]
+    pub messenger_redis_batch_size: String,
+    #[arg(long, env, default_value = "25")]
+    pub messenger_queue_connections: u64,
+    #[arg(long, env, default_value = "TXNFILL")]
+    pub messenger_queue_stream: String,
+}
+
+impl From<QueueArgs> for MessengerConfig {
+    fn from(args: QueueArgs) -> Self {
+        let mut connection_config = Dict::new();
+
+        connection_config.insert(
+            "redis_connection_str".to_string(),
+            Value::from(args.messenger_redis_url),
+        );
+        connection_config.insert(
+            "batch_size".to_string(),
+            Value::from(args.messenger_redis_batch_size),
+        );
+        connection_config.insert(
+            "pipeline_size_bytes".to_string(),
+            Value::from(1u128.to_string()),
+        );
+
+        Self {
+            messenger_type: MessengerType::Redis,
+            connection_config,
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum QueuePoolError {
+    #[error("messenger")]
+    Messenger(#[from] plerkle_messenger::MessengerError),
+    #[error("tokio try send to channel")]
+    TrySendMessengerChannel(#[from] TrySendError<Box<dyn Messenger>>),
+    #[error("revc messenger connection")]
+    RecvMessengerConnection,
+    #[error("try from int")]
+    TryFromInt(#[from] TryFromIntError),
+    #[error("tokio send to channel")]
+    SendMessengerChannel(#[from] mpsc::error::SendError<Box<dyn Messenger>>),
+}
+
+#[derive(Debug, Clone)]
+pub struct QueuePool {
+    tx: mpsc::Sender<Box<dyn plerkle_messenger::Messenger>>,
+    rx: Arc<Mutex<mpsc::Receiver<Box<dyn plerkle_messenger::Messenger>>>>,
+}
+
+impl QueuePool {
+    pub async fn try_from_config(config: QueueArgs) -> anyhow::Result<Self, QueuePoolError> {
+        let size = usize::try_from(config.messenger_queue_connections)?;
+        let (tx, rx) = mpsc::channel(size);
+
+        for _ in 0..config.messenger_queue_connections {
+            let messenger_config: MessengerConfig = config.clone().into();
+            let mut messenger = plerkle_messenger::select_messenger(messenger_config).await?;
+            messenger.add_stream(TRANSACTION_BACKFILL_STREAM).await?;
+            messenger
+                .set_buffer_size(TRANSACTION_BACKFILL_STREAM, 10_000_000)
+                .await;
+
+            tx.try_send(messenger)?;
+        }
+
+        Ok(Self {
+            tx,
+            rx: Arc::new(Mutex::new(rx)),
+        })
+    }
+
+    pub async fn push(&self, message: &[u8]) -> Result<(), QueuePoolError> {
+        let mut rx = self.rx.lock().await;
+        let mut messenger = rx
+            .recv()
+            .await
+            .ok_or(QueuePoolError::RecvMessengerConnection)?;
+
+        messenger.send(TRANSACTION_BACKFILL_STREAM, message).await?;
+
+        self.tx.send(messenger).await?;
+
+        Ok(())
+    }
+}

--- a/ops/src/bubblegum/rpc.rs
+++ b/ops/src/bubblegum/rpc.rs
@@ -1,0 +1,135 @@
+use anyhow::Result;
+use backon::ExponentialBuilder;
+use backon::Retryable;
+use clap::Parser;
+use solana_account_decoder::UiAccountEncoding;
+use solana_client::rpc_response::RpcConfirmedTransactionStatusWithSignature;
+use solana_client::{
+    client_error::ClientError,
+    nonblocking::rpc_client::RpcClient,
+    rpc_client::GetConfirmedSignaturesForAddress2Config,
+    rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig, RpcTransactionConfig},
+    rpc_filter::RpcFilterType,
+};
+use solana_sdk::{
+    account::Account,
+    commitment_config::{CommitmentConfig, CommitmentLevel},
+    pubkey::Pubkey,
+    signature::Signature,
+};
+use solana_transaction_status::EncodedConfirmedTransactionWithStatusMeta;
+use solana_transaction_status::UiTransactionEncoding;
+use std::sync::Arc;
+
+#[derive(Clone, Parser, Debug)]
+pub struct SolanaRpcArgs {
+    #[arg(long, env)]
+    pub solana_rpc_url: String,
+}
+
+#[derive(Clone)]
+pub struct Rpc(Arc<RpcClient>);
+
+impl Rpc {
+    pub fn from_config(config: SolanaRpcArgs) -> Self {
+        Rpc(Arc::new(RpcClient::new(config.solana_rpc_url)))
+    }
+
+    pub async fn get_transaction(
+        &self,
+        signature: &Signature,
+    ) -> Result<EncodedConfirmedTransactionWithStatusMeta, ClientError> {
+        (|| async {
+            self.0
+                .get_transaction_with_config(
+                    signature,
+                    RpcTransactionConfig {
+                        encoding: Some(UiTransactionEncoding::Base58),
+                        max_supported_transaction_version: Some(0),
+                        commitment: Some(CommitmentConfig {
+                            commitment: CommitmentLevel::Finalized,
+                        }),
+                    },
+                )
+                .await
+        })
+        .retry(&ExponentialBuilder::default())
+        .await
+    }
+
+    pub async fn get_signatures_for_address(
+        &self,
+        pubkey: &Pubkey,
+        before: Option<Signature>,
+        until: Option<Signature>,
+    ) -> Result<Vec<RpcConfirmedTransactionStatusWithSignature>, ClientError> {
+        (|| async {
+            self.0
+                .get_signatures_for_address_with_config(
+                    pubkey,
+                    GetConfirmedSignaturesForAddress2Config {
+                        before,
+                        until,
+                        commitment: Some(CommitmentConfig {
+                            commitment: CommitmentLevel::Finalized,
+                        }),
+                        ..GetConfirmedSignaturesForAddress2Config::default()
+                    },
+                )
+                .await
+        })
+        .retry(&ExponentialBuilder::default())
+        .await
+    }
+
+    pub async fn get_program_accounts(
+        &self,
+        program: &Pubkey,
+        filters: Option<Vec<RpcFilterType>>,
+    ) -> Result<Vec<(Pubkey, Account)>, ClientError> {
+        (|| async {
+            let filters = filters.clone();
+
+            self.0
+                .get_program_accounts_with_config(
+                    program,
+                    RpcProgramAccountsConfig {
+                        filters,
+                        account_config: RpcAccountInfoConfig {
+                            encoding: Some(UiAccountEncoding::Base64),
+                            commitment: Some(CommitmentConfig {
+                                commitment: CommitmentLevel::Finalized,
+                            }),
+                            ..RpcAccountInfoConfig::default()
+                        },
+                        ..RpcProgramAccountsConfig::default()
+                    },
+                )
+                .await
+        })
+        .retry(&ExponentialBuilder::default())
+        .await
+    }
+
+    pub async fn get_multiple_accounts(
+        &self,
+        pubkeys: &[Pubkey],
+    ) -> Result<Vec<Option<Account>>, ClientError> {
+        Ok((|| async {
+            self.0
+                .get_multiple_accounts_with_config(
+                    pubkeys,
+                    RpcAccountInfoConfig {
+                        commitment: Some(CommitmentConfig {
+                            commitment: CommitmentLevel::Finalized,
+                        }),
+                        ..RpcAccountInfoConfig::default()
+                    },
+                )
+                .await
+        })
+        .retry(&ExponentialBuilder::default())
+        .await?
+        .value)
+    }
+}

--- a/ops/src/bubblegum/tree.rs
+++ b/ops/src/bubblegum/tree.rs
@@ -1,0 +1,272 @@
+use anyhow::Result;
+use borsh::BorshDeserialize;
+use clap::Args;
+use log::error;
+use sea_orm::{DatabaseConnection, DbBackend, FromQueryResult, Statement, Value};
+use solana_client::rpc_filter::{Memcmp, RpcFilterType};
+use solana_sdk::{account::Account, pubkey::Pubkey, signature::Signature};
+use spl_account_compression::id;
+use spl_account_compression::state::{
+    merkle_tree_get_size, ConcurrentMerkleTreeHeader, CONCURRENT_MERKLE_TREE_HEADER_SIZE_V1,
+};
+use std::str::FromStr;
+use thiserror::Error as ThisError;
+use tokio::sync::mpsc::Sender;
+
+use super::{queue::QueuePoolError, rpc::Rpc};
+
+const GET_SIGNATURES_FOR_ADDRESS_LIMIT: usize = 1000;
+
+#[derive(Debug, Clone, Args)]
+pub struct ConfigBackfiller {
+    /// Solana RPC URL
+    #[arg(long, env)]
+    pub solana_rpc_url: String,
+}
+
+#[derive(ThisError, Debug)]
+pub enum TreeErrorKind {
+    #[error("solana rpc")]
+    Rpc(#[from] solana_client::client_error::ClientError),
+    #[error("anchor")]
+    Achor(#[from] anchor_client::anchor_lang::error::Error),
+    #[error("perkle serialize")]
+    PerkleSerialize(#[from] plerkle_serialization::error::PlerkleSerializationError),
+    #[error("perkle messenger")]
+    PlerkleMessenger(#[from] plerkle_messenger::MessengerError),
+    #[error("queue pool")]
+    QueuePool(#[from] QueuePoolError),
+    #[error("parse pubkey")]
+    ParsePubkey(#[from] solana_sdk::pubkey::ParsePubkeyError),
+    #[error("serialize tree response")]
+    SerializeTreeResponse,
+    #[error("sea orm")]
+    Database(#[from] sea_orm::DbErr),
+    #[error("try from pubkey")]
+    TryFromPubkey,
+    #[error("try from signature")]
+    TryFromSignature,
+}
+
+const TREE_GAP_SQL: &str = r#"
+WITH sequenced_data AS (
+    SELECT
+        tree,
+        seq,
+        LEAD(seq) OVER (ORDER BY seq ASC) AS next_seq,
+        tx AS current_tx,
+        LEAD(tx) OVER (ORDER BY seq ASC) AS next_tx
+    FROM
+        cl_audits_v2
+    WHERE
+        tree = $1
+),
+gaps AS (
+    SELECT
+        tree,
+        seq AS gap_start_seq,
+        next_seq AS gap_end_seq,
+        current_tx AS lower_bound_tx,
+        next_tx AS upper_bound_tx
+    FROM
+        sequenced_data
+    WHERE
+        next_seq IS NOT NULL AND
+        next_seq - seq > 1
+)
+SELECT
+    tree,
+    gap_start_seq,
+    gap_end_seq,
+    lower_bound_tx,
+    upper_bound_tx
+FROM
+    gaps
+ORDER BY
+    gap_start_seq;
+"#;
+
+#[derive(Debug, FromQueryResult, PartialEq, Clone)]
+pub struct TreeGapModel {
+    pub tree: Vec<u8>,
+    pub gap_start_seq: i64,
+    pub gap_end_seq: i64,
+    pub lower_bound_tx: Vec<u8>,
+    pub upper_bound_tx: Vec<u8>,
+}
+
+impl TreeGapModel {
+    pub async fn find(conn: &DatabaseConnection, tree: Pubkey) -> Result<Vec<Self>, TreeErrorKind> {
+        let statement = Statement::from_sql_and_values(
+            DbBackend::Postgres,
+            TREE_GAP_SQL,
+            vec![Value::Bytes(Some(Box::new(tree.as_ref().to_vec())))],
+        );
+
+        TreeGapModel::find_by_statement(statement)
+            .all(conn)
+            .await
+            .map_err(Into::into)
+    }
+}
+
+impl TryFrom<TreeGapModel> for TreeGapFill {
+    type Error = TreeErrorKind;
+
+    fn try_from(model: TreeGapModel) -> Result<Self, Self::Error> {
+        let tree = Pubkey::try_from(model.tree).map_err(|_| TreeErrorKind::TryFromPubkey)?;
+        let upper = Signature::try_from(model.upper_bound_tx)
+            .map_err(|_| TreeErrorKind::TryFromSignature)?;
+        let lower = Signature::try_from(model.lower_bound_tx)
+            .map_err(|_| TreeErrorKind::TryFromSignature)?;
+
+        Ok(Self::new(tree, Some(upper), Some(lower)))
+    }
+}
+
+pub struct TreeGapFill {
+    tree: Pubkey,
+    before: Option<Signature>,
+    until: Option<Signature>,
+}
+
+impl TreeGapFill {
+    pub fn new(tree: Pubkey, before: Option<Signature>, until: Option<Signature>) -> Self {
+        Self {
+            tree,
+            before,
+            until,
+        }
+    }
+
+    pub async fn crawl(&self, client: Rpc, sender: Sender<Signature>) -> Result<()> {
+        let mut before = self.before;
+
+        loop {
+            let sigs = client
+                .get_signatures_for_address(&self.tree, before, self.until)
+                .await?;
+
+            for sig in sigs.iter() {
+                let sig = Signature::from_str(&sig.signature)?;
+
+                sender.send(sig).await?;
+
+                before = Some(sig);
+            }
+
+            if sigs.len() < GET_SIGNATURES_FOR_ADDRESS_LIMIT {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TreeHeaderResponse {
+    pub max_depth: u32,
+    pub max_buffer_size: u32,
+    pub creation_slot: u64,
+    pub size: usize,
+}
+
+impl TryFrom<ConcurrentMerkleTreeHeader> for TreeHeaderResponse {
+    type Error = TreeErrorKind;
+
+    fn try_from(payload: ConcurrentMerkleTreeHeader) -> Result<Self, Self::Error> {
+        let size = merkle_tree_get_size(&payload)?;
+
+        Ok(Self {
+            max_depth: payload.get_max_depth(),
+            max_buffer_size: payload.get_max_buffer_size(),
+            creation_slot: payload.get_creation_slot(),
+            size,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TreeResponse {
+    pub pubkey: Pubkey,
+    pub tree_header: TreeHeaderResponse,
+    pub seq: u64,
+}
+
+impl TreeResponse {
+    pub fn try_from_rpc(pubkey: Pubkey, account: Account) -> Result<Self> {
+        let bytes = account.data.as_slice();
+
+        let (header_bytes, rest) = bytes.split_at(CONCURRENT_MERKLE_TREE_HEADER_SIZE_V1);
+        let header: ConcurrentMerkleTreeHeader =
+            ConcurrentMerkleTreeHeader::try_from_slice(header_bytes)?;
+
+        let merkle_tree_size = merkle_tree_get_size(&header)?;
+        let (tree_bytes, _canopy_bytes) = rest.split_at(merkle_tree_size);
+
+        let seq_bytes = tree_bytes[0..8].try_into()?;
+        let seq = u64::from_le_bytes(seq_bytes);
+
+        let (auth, _) = Pubkey::find_program_address(&[pubkey.as_ref()], &mpl_bubblegum::ID);
+
+        header.assert_valid_authority(&auth)?;
+
+        let tree_header = header.try_into()?;
+
+        Ok(Self {
+            pubkey,
+            tree_header,
+            seq,
+        })
+    }
+
+    pub async fn all(client: &Rpc) -> Result<Vec<Self>, TreeErrorKind> {
+        Ok(client
+            .get_program_accounts(
+                &id(),
+                Some(vec![RpcFilterType::Memcmp(Memcmp::new_raw_bytes(
+                    0,
+                    vec![1u8],
+                ))]),
+            )
+            .await?
+            .into_iter()
+            .filter_map(|(pubkey, account)| Self::try_from_rpc(pubkey, account).ok())
+            .collect())
+    }
+
+    pub async fn find(client: &Rpc, pubkeys: Vec<String>) -> Result<Vec<Self>, TreeErrorKind> {
+        let pubkeys: Vec<Pubkey> = pubkeys
+            .into_iter()
+            .map(|p| Pubkey::from_str(&p))
+            .collect::<Result<Vec<Pubkey>, _>>()?;
+        let pubkey_batches = pubkeys.chunks(100);
+        let pubkey_batches_count = pubkey_batches.len();
+
+        let mut gma_handles = Vec::with_capacity(pubkey_batches_count);
+
+        for batch in pubkey_batches {
+            gma_handles.push(async move {
+                let accounts = client.get_multiple_accounts(batch).await?;
+
+                let results: Vec<(&Pubkey, Option<Account>)> = batch.iter().zip(accounts).collect();
+
+                Ok::<_, TreeErrorKind>(results)
+            })
+        }
+
+        let result = futures::future::try_join_all(gma_handles).await?;
+
+        let trees = result
+            .into_iter()
+            .flatten()
+            .filter_map(|(pubkey, account)| {
+                account.map(|account| Self::try_from_rpc(*pubkey, account))
+            })
+            .collect::<Result<Vec<TreeResponse>, _>>()
+            .map_err(|_| TreeErrorKind::SerializeTreeResponse)?;
+
+        Ok(trees)
+    }
+}

--- a/ops/src/main.rs
+++ b/ops/src/main.rs
@@ -1,0 +1,31 @@
+mod bubblegum;
+
+use anyhow::Result;
+use bubblegum::{subcommand as bubblegum_subcommand, BubblegumCommand};
+use clap::{Parser, Subcommand};
+
+#[derive(Debug, Parser)]
+#[clap(author, version)]
+struct Args {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    #[clap(name = "bubblegum")]
+    Bubblegum(BubblegumCommand),
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+
+    env_logger::init();
+
+    match args.command {
+        Command::Bubblegum(subcommand) => bubblegum_subcommand(subcommand).await?,
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
resolves https://github.com/metaplex-foundation/digital-asset-rpc-infrastructure/issues/150

## Goal
Implement a rapid, efficient, and reliable method for backfilling any missing updates to bubblegum trees.

## Changes
- Introduce an ops crate that consolidates various operational tools utilized by DAS operators.
- Implement a bubblegum backfill command. This command detects absent trees and their sequences within the index by referencing cl_audits_v2. It then requests missing transactions for a tree using getSignaturesForAddress to requeue any missed transactions. For usage details and methodology, refer to the bubblegum module's [README](https://github.com/metaplex-foundation/digital-asset-rpc-infrastructure/blob/78479394b8465d9353515513bdc9a986b6079316/ops/src/bubblegum/README.md).

## Testing
At Triton, the backfill command successfully populated a new DAS installation with all bubblegum transactions in ~30 hours. The duration of indexing is contingent on the number of worker processes and the RPC response time, especially when retrieving older transactions from the archive.

The command has also been applied incrementally over the past month to backfill only missing transactions, taking between 2 to 5 minutes depending on the number and size of missing sequence gaps.

## Discussion
1. I welcome any alternative suggestions for organizing DAS-related tools. With community approval, I plan to merge the various tool crates into this ops package.
