### PR TITLE
Fix cNFT update metadata indexing

### DIFF
--- a/nft_ingester/src/program_transformers/bubblegum/update_metadata.rs
+++ b/nft_ingester/src/program_transformers/bubblegum/update_metadata.rs
@@ -60,11 +60,6 @@ where
                 } else {
                     current_metadata.uri.replace('\0', "")
                 };
-                if uri.is_empty() {
-                    return Err(IngesterError::DeserializationError(
-                        "URI is empty".to_string(),
-                    ));
-                }
 
                 let name = if let Some(name) = update_args.name.clone() {
                     name


### PR DESCRIPTION
# Overview
- Empty URI's are allowed. This caused the transaction indexing to fail.
- At the time of writing, the only impacted asset is `5xg1NhPgYajc3LYzv5T5RT9vfxVP3s2uyT9zTb9azu1f`. I recommend other providers scan their logs and verify no other assets have been impacted since we fixed it.

# Testing
- Re-indexed the record in Helius' production environment