### PR TITLE
Make rollup processing feature optional

### DIFF
--- a/nft_ingester/src/config.rs
+++ b/nft_ingester/src/config.rs
@@ -31,7 +31,7 @@ pub struct IngesterConfig {
     pub code_version: Option<&'static str>,
     pub background_task_runner_config: Option<BackgroundTaskRunnerConfig>,
     pub cl_audits: Option<bool>, // save transaction logs for compressed nfts
-    pub process_rollups: Option<bool>,
+    pub skip_rollup_indexing: bool,
 }
 
 #[derive(Deserialize, PartialEq, Debug, Clone)]

--- a/nft_ingester/src/config.rs
+++ b/nft_ingester/src/config.rs
@@ -31,6 +31,7 @@ pub struct IngesterConfig {
     pub code_version: Option<&'static str>,
     pub background_task_runner_config: Option<BackgroundTaskRunnerConfig>,
     pub cl_audits: Option<bool>, // save transaction logs for compressed nfts
+    pub process_rollups: Option<bool>,
 }
 
 #[derive(Deserialize, PartialEq, Debug, Clone)]

--- a/nft_ingester/src/main.rs
+++ b/nft_ingester/src/main.rs
@@ -154,17 +154,19 @@ pub async fn main() -> Result<(), IngesterError> {
             }
         }
 
-        let rollup_persister = RollupPersister::new(
-            Arc::new(SqlxPostgresConnector::from_sqlx_postgres_pool(
-                database_pool.clone(),
-            )),
-            config.get_database_url(),
-            RollupDownloaderForPersister {},
-        );
-        tasks.spawn(async move {
-            rollup_persister.persist_rollups().await;
-            Ok(())
-        });
+        if config.process_rollups.unwrap_or_default() {
+            let rollup_persister = RollupPersister::new(
+                Arc::new(SqlxPostgresConnector::from_sqlx_postgres_pool(
+                    database_pool.clone(),
+                )),
+                config.get_database_url(),
+                RollupDownloaderForPersister {},
+            );
+            tasks.spawn(async move {
+                rollup_persister.persist_rollups().await;
+                Ok(())
+            });
+        }
     }
     // Stream Size Timers ----------------------------------------
     // Setup Stream Size Timers, these are small processes that run every 60 seconds and farm metrics for the size of the streams.

--- a/nft_ingester/src/main.rs
+++ b/nft_ingester/src/main.rs
@@ -154,7 +154,7 @@ pub async fn main() -> Result<(), IngesterError> {
             }
         }
 
-        if config.process_rollups.unwrap_or_default() {
+        if !config.skip_rollup_indexing {
             let rollup_persister = RollupPersister::new(
                 Arc::new(SqlxPostgresConnector::from_sqlx_postgres_pool(
                     database_pool.clone(),


### PR DESCRIPTION
# What
This PR makes parsing rollups as an optional feature which could be enabled/disabled through the config.
# Why
Rollups data may take lot of space and not every DAS API operator is ready to store it.
# How
Was added a new config parameter and check of this paramenter in main func.