### PR TITLE
fix : cargo clippy for rust-1.79

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4937,9 +4937,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
 
 [[package]]
 name = "rustc_version"

--- a/digital_asset_types/src/dapi/change_logs.rs
+++ b/digital_asset_types/src/dapi/change_logs.rs
@@ -200,22 +200,18 @@ fn build_asset_proof(
     tree_id: Vec<u8>,
     leaf_node_idx: i64,
     leaf_hash: Vec<u8>,
-    req_indexes: &Vec<i64>,
+    req_indexes: &[i64],
     required_nodes: &[SimpleChangeLog],
 ) -> AssetProof {
     let mut final_node_list = vec![SimpleChangeLog::default(); req_indexes.len()];
     for node in required_nodes.iter() {
         if node.level < final_node_list.len().try_into().unwrap() {
-            final_node_list[node.level as usize] = node.to_owned();
+            node.clone_into(&mut final_node_list[node.level as usize])
         }
     }
-    for (i, (n, nin)) in final_node_list
-        .iter_mut()
-        .zip(req_indexes.clone())
-        .enumerate()
-    {
+    for (i, (n, nin)) in final_node_list.iter_mut().zip(req_indexes).enumerate() {
         if *n == SimpleChangeLog::default() {
-            *n = make_empty_node(i as i64, nin, tree_id.clone());
+            *n = make_empty_node(i as i64, *nin, tree_id.clone());
         }
     }
     AssetProof {

--- a/digital_asset_types/tests/common.rs
+++ b/digital_asset_types/tests/common.rs
@@ -31,9 +31,12 @@ pub struct MockMetadataArgs {
     /// Since we cannot easily change Metadata, we add the new DataV2 fields here at the end.
     pub token_standard: Option<TokenStandard>,
     /// Collection
+    #[allow(dead_code)]
     pub collection: Option<Collection>,
     /// Uses
+    #[allow(dead_code)]
     pub uses: Option<Uses>,
+    /// Creators
     pub creators: Vec<Creator>,
 }
 

--- a/nft_ingester/src/backfiller.rs
+++ b/nft_ingester/src/backfiller.rs
@@ -66,6 +66,7 @@ const BLOCK_CACHE_SIZE: usize = 300_000;
 const MAX_CACHE_COST: i64 = 32;
 const BLOCK_CACHE_DURATION: u64 = 172800;
 
+#[allow(dead_code)]
 struct SlotSeq(u64, u64);
 /// Main public entry point for backfiller task.
 pub fn setup_backfiller<T: Messenger>(
@@ -799,12 +800,7 @@ impl<'a, T: Messenger> Backfiller<'a, T> {
             .build(DbBackend::Postgres);
 
         let start_seq_vec = MaxSeqItem::find_by_statement(query).all(&self.db).await?;
-        let start_seq = if let Some(seq) = start_seq_vec.last().map(|row| row.seq) {
-            seq
-        } else {
-            0
-        };
-
+        let start_seq = start_seq_vec.last().map(|row| row.seq).unwrap_or_default();
         // Get all rows for the tree that have not yet been backfilled.
         let mut query = backfill_items::Entity::find()
             .select_only()

--- a/nft_ingester/src/plerkle.rs
+++ b/nft_ingester/src/plerkle.rs
@@ -17,7 +17,7 @@ pub enum PlerkleDeserializerError {
 
 pub struct PlerkleAccountInfo<'a>(pub plerkle_serialization::AccountInfo<'a>);
 
-impl<'a> TryFrom<PlerkleAccountInfo<'a>> for AccountInfo {
+impl TryFrom<PlerkleAccountInfo<'_>> for AccountInfo {
     type Error = PlerkleDeserializerError;
 
     fn try_from(value: PlerkleAccountInfo) -> Result<Self, Self::Error> {

--- a/nft_ingester/src/tasks/mod.rs
+++ b/nft_ingester/src/tasks/mod.rs
@@ -324,8 +324,8 @@ impl TaskManager {
         tokio::task::spawn(async move {
             while let Some(task) = receiver.recv().await {
                 if let Some(task_created_time) = task.created_at {
-                    let bus_time =
-                        Utc::now().timestamp_millis() - task_created_time.timestamp_millis();
+                    let bus_time = Utc::now().timestamp_millis()
+                        - task_created_time.and_utc().timestamp_millis();
                     metric! {
                         statsd_histogram!("ingester.bgtask.bus_time", bus_time as u64, "type" => task.name);
                     }

--- a/ops/src/bubblegum/tree.rs
+++ b/ops/src/bubblegum/tree.rs
@@ -171,6 +171,7 @@ impl TreeGapFill {
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct TreeHeaderResponse {
     pub max_depth: u32,
     pub max_buffer_size: u32,
@@ -196,6 +197,7 @@ impl TryFrom<ConcurrentMerkleTreeHeader> for TreeHeaderResponse {
 #[derive(Debug, Clone)]
 pub struct TreeResponse {
     pub pubkey: Pubkey,
+    #[allow(dead_code)]
     pub tree_header: TreeHeaderResponse,
     pub seq: u64,
 }

--- a/program_transformers/src/bubblegum/db.rs
+++ b/program_transformers/src/bubblegum/db.rs
@@ -529,7 +529,7 @@ where
 pub async fn upsert_asset_creators<T>(
     txn: &T,
     id: Vec<u8>,
-    creators: &Vec<Creator>,
+    creators: &[Creator],
     slot_updated: i64,
     seq: i64,
 ) -> ProgramTransformerResult<()>

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.79.0"
 components = ["clippy", "rustfmt"]
 targets = []
 profile = "minimal"


### PR DESCRIPTION
grpc-ingest branch will use rust-1.79 and this will cause clippy warnings so making this pr to fix those clippy warnings 

## Changes
- Upgrade rust toolchain to 1.79
- Resolve clippy warnings
