### PR TITLE
fix crate vulnerabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3945,7 +3945,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.100",


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2024-0332
https://rustsec.org/advisories/RUSTSEC-2024-0402
https://rustsec.org/advisories/RUSTSEC-2024-0019
https://rustsec.org/advisories/RUSTSEC-2025-0004
https://rustsec.org/advisories/RUSTSEC-2024-0020
https://rustsec.org/advisories/RUSTSEC-2024-0404
https://rustsec.org/advisories/RUSTSEC-2023-0075

Also updated yanked crate `ahash`, `bumpalo` `spl-tlv-account-resolution`.