### PR TITLE
Update rust version in toolchain file and docker files

### DIFF
--- a/Api.Dockerfile
+++ b/Api.Dockerfile
@@ -1,5 +1,5 @@
 FROM das-api/builder AS files
-FROM rust:1.75-slim-bullseye
+FROM rust:1.81-slim-bullseye
 ARG APP=/usr/src/app
 RUN apt update \
     && apt install -y curl ca-certificates tzdata \

--- a/Builder.Dockerfile
+++ b/Builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.76-bullseye AS builder
+FROM rust:1.81-bullseye AS builder
 RUN apt-get update -y && \
     apt-get install -y build-essential make git
     
@@ -20,6 +20,6 @@ WORKDIR /rust
 RUN --mount=type=cache,target=/rust/target,id=das-rust \
   cargo build --release --bins && cp `find /rust/target/release -maxdepth 1 -type f | sed 's/^\.\///' | grep -v "\." ` /rust/bins
     
-FROM rust:1.75-slim-bullseye as final
+FROM rust:1.81-slim-bullseye as final
 COPY --from=builder /rust/bins /das/
 CMD echo "Built the DAS API bins!"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,7 +550,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.29",
+ "time 0.3.37",
 ]
 
 [[package]]
@@ -1870,10 +1870,11 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
+ "powerfmt",
  "serde",
 ]
 
@@ -3700,6 +3701,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4246,6 +4253,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4631,7 +4644,7 @@ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
  "ring 0.16.20",
- "time 0.3.29",
+ "time 0.3.37",
  "yasna",
 ]
 
@@ -5146,7 +5159,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "thiserror",
- "time 0.3.29",
+ "time 0.3.37",
  "tracing",
  "url",
  "uuid",
@@ -5207,7 +5220,7 @@ dependencies = [
  "rust_decimal",
  "sea-query-derive 0.2.0",
  "serde_json",
- "time 0.3.29",
+ "time 0.3.37",
  "uuid",
 ]
 
@@ -5231,7 +5244,7 @@ dependencies = [
  "sea-query 0.27.2",
  "serde_json",
  "sqlx",
- "time 0.3.29",
+ "time 0.3.37",
  "uuid",
 ]
 
@@ -5440,7 +5453,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_with_macros 3.6.1",
- "time 0.3.29",
+ "time 0.3.37",
 ]
 
 [[package]]
@@ -6769,7 +6782,7 @@ dependencies = [
  "sqlx-rt",
  "stringprep",
  "thiserror",
- "time 0.3.29",
+ "time 0.3.37",
  "tokio-stream",
  "url",
  "uuid",
@@ -7031,12 +7044,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.29"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -7050,10 +7065,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
@@ -8056,7 +8072,7 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time 0.3.29",
+ "time 0.3.37",
 ]
 
 [[package]]
@@ -8086,7 +8102,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "time 0.3.29",
+ "time 0.3.37",
 ]
 
 [[package]]

--- a/Ingest.Dockerfile
+++ b/Ingest.Dockerfile
@@ -1,5 +1,5 @@
 FROM das-api/builder AS files
-FROM rust:1.75-slim-bullseye
+FROM rust:1.81-slim-bullseye
 ARG APP=/usr/src/app
 RUN apt update \
     && apt install -y curl ca-certificates tzdata \

--- a/Load.Dockerfile
+++ b/Load.Dockerfile
@@ -1,5 +1,5 @@
 FROM das-api/builder AS files
-FROM rust:1.75-slim-bullseye
+FROM rust:1.81-slim-bullseye
 ARG APP=/usr/src/app
 RUN apt update \
     && apt install -y curl ca-certificates tzdata \

--- a/Migrator.Dockerfile
+++ b/Migrator.Dockerfile
@@ -1,6 +1,6 @@
 FROM das-api/builder AS files
 
-FROM rust:1.76-bullseye
+FROM rust:1.81-bullseye
 COPY init.sql /init.sql
 ENV INIT_FILE_PATH=/init.sql
 COPY --from=files /das/migration /bins/migration

--- a/Proxy.Dockerfile
+++ b/Proxy.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.76-bullseye AS builder
+FROM rust:1.81-bullseye AS builder
 RUN cargo install wasm-pack
 
 RUN mkdir /rust

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.79.0"
+channel = "1.81.0"
 components = ["clippy", "rustfmt"]
 targets = []
 profile = "minimal"


### PR DESCRIPTION
### Docker
I did also try using the lockfile and passing `--locked` to the docker build, but this causes an issue with `cargo install wasm-pack` which still needs the latest Rust version, so just opted to update Rust version.

### Local toolchain file
Updating to latest Rust caused me to need to update time crate as well.

### Testing
Local build works and `docker compose up --force-recreate --build` works.