### PR TITLE
`impr`: add composite index (owner,amount) and (mint,owner) on token_a…

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -46,6 +46,8 @@ mod m20240520_120101_add_mpl_core_external_plugins_columns;
 mod m20240718_161232_change_supply_columns_to_numeric;
 mod m20241119_060310_add_token_inscription_enum_variant;
 mod m20250213_053451_add_idx_token_accounts_owner;
+mod m20250313_105132_drop_idx_token_accounts_owner_and_idx_ta_mint;
+mod m20250313_105206_add_idx_ta_owner_amount_and_idx_ta_mint_amount;
 
 pub mod model;
 
@@ -101,6 +103,8 @@ impl MigratorTrait for Migrator {
             Box::new(m20240718_161232_change_supply_columns_to_numeric::Migration),
             Box::new(m20241119_060310_add_token_inscription_enum_variant::Migration),
             Box::new(m20250213_053451_add_idx_token_accounts_owner::Migration),
+            Box::new(m20250313_105132_drop_idx_token_accounts_owner_and_idx_ta_mint::Migration),
+            Box::new(m20250313_105206_add_idx_ta_owner_amount_and_idx_ta_mint_amount::Migration),
         ]
     }
 }

--- a/migration/src/m20250313_105132_drop_idx_token_accounts_owner_and_idx_ta_mint.rs
+++ b/migration/src/m20250313_105132_drop_idx_token_accounts_owner_and_idx_ta_mint.rs
@@ -1,0 +1,50 @@
+use super::model::table::TokenAccounts;
+use sea_orm::{ConnectionTrait, DatabaseBackend, Statement};
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("token_accounts_owner_idx")
+                    .table(TokenAccounts::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("ta_mint")
+                    .table(TokenAccounts::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+
+        conn.execute(Statement::from_string(
+            DatabaseBackend::Postgres,
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS token_accounts_owner_idx ON token_accounts (owner);"
+                .to_string(),
+        ))
+        .await?;
+
+        conn.execute(Statement::from_string(
+            DatabaseBackend::Postgres,
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ta_mint ON token_accounts (mint);".to_string(),
+        ))
+        .await?;
+
+        Ok(())
+    }
+}

--- a/migration/src/m20250313_105206_add_idx_ta_owner_amount_and_idx_ta_mint_amount.rs
+++ b/migration/src/m20250313_105206_add_idx_ta_owner_amount_and_idx_ta_mint_amount.rs
@@ -1,0 +1,51 @@
+use super::model::table::TokenAccounts;
+use sea_orm::{ConnectionTrait, DatabaseBackend, Statement};
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+
+        conn.execute(Statement::from_string(
+            DatabaseBackend::Postgres,
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ta_owner_amount ON token_accounts (owner,amount);"
+                .to_string(),
+        ))
+        .await?;
+
+        conn.execute(Statement::from_string(
+            DatabaseBackend::Postgres,
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ta_mint_amount ON token_accounts (mint,amount);"
+                .to_string(),
+        ))
+        .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("ta_owner_amount")
+                    .table(TokenAccounts::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("ta_mint_amount")
+                    .table(TokenAccounts::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
getTokenAccounts calls were kind of slow as we have amount > 0 as a default condition , adding a composite index (owner,amount) and (mint,amount) can fix this potentially and reduce the latency