### PR TITLE
Change ordering in get_token_accounts_by_owner integ test result

### DIFF
--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__token_accounts_tests__get_token_accounts_by_owner.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__token_accounts_tests__get_token_accounts_by_owner.snap
@@ -1,16 +1,16 @@
 ---
 source: integration_tests/tests/integration_tests/token_accounts_tests.rs
+assertion_line: 73
 expression: response
-snapshot_kind: text
 ---
 {
   "total": 2,
   "limit": 1000,
   "token_accounts": [
     {
-      "address": "jKLTJu7nE1zLmC2J2xjVVBm4G7vJcKGCGQX36Jrsba2",
-      "mint": "wKocBVvHQoVaiwWoCs9JYSVye4YZRrv5Cucf7fDqnz1",
-      "amount": 1000000000000,
+      "address": "3Pv9H5UzU8T9BwgutXrcn2wLohS1JUZuk3x8paiRyzui",
+      "mint": "F3D8Priw3BRecH36BuMubQHrTUn1QxmupLHEmmbZ4LXW",
+      "amount": 10000,
       "owner": "CeviT1DTQLuicEB7yLeFkkAGmam5GnJssbGb7CML4Tgx",
       "frozen": false,
       "delegate": null,
@@ -19,9 +19,9 @@ snapshot_kind: text
       "extensions": null
     },
     {
-      "address": "3Pv9H5UzU8T9BwgutXrcn2wLohS1JUZuk3x8paiRyzui",
-      "mint": "F3D8Priw3BRecH36BuMubQHrTUn1QxmupLHEmmbZ4LXW",
-      "amount": 10000,
+      "address": "jKLTJu7nE1zLmC2J2xjVVBm4G7vJcKGCGQX36Jrsba2",
+      "mint": "wKocBVvHQoVaiwWoCs9JYSVye4YZRrv5Cucf7fDqnz1",
+      "amount": 1000000000000,
       "owner": "CeviT1DTQLuicEB7yLeFkkAGmam5GnJssbGb7CML4Tgx",
       "frozen": false,
       "delegate": null,


### PR DESCRIPTION
I think since we have this code:
```
    let token_accounts = paginate(
        pagination,
        limit,
        token_accounts::Entity::find().filter(condition),
        Order::Asc,
        token_accounts::Column::Pubkey,
    )
    .all(conn)
    .await?;
 ```
 
 It is expected to order by ascending which means numbers come first before letters in Postgres.   
