### PR TITLE
Fix metaplex-rpc-proxy and docker build

### DIFF
--- a/Api.Dockerfile
+++ b/Api.Dockerfile
@@ -1,5 +1,5 @@
 FROM das-api/builder AS files
-FROM rust:1.81-slim-bullseye
+FROM rust:1.82-slim-bullseye
 ARG APP=/usr/src/app
 RUN apt update \
     && apt install -y curl ca-certificates tzdata \

--- a/Builder.Dockerfile
+++ b/Builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.81-bullseye AS builder
+FROM rust:1.82-bullseye AS builder
 RUN apt-get update -y && \
     apt-get install -y build-essential make git
     
@@ -21,6 +21,6 @@ WORKDIR /rust
 RUN --mount=type=cache,target=/rust/target,id=das-rust \
   cargo build --release --bins && cp `find /rust/target/release -maxdepth 1 -type f | sed 's/^\.\///' | grep -v "\." ` /rust/bins
     
-FROM rust:1.81-slim-bullseye as final
+FROM rust:1.82-slim-bullseye as final
 COPY --from=builder /rust/bins /das/
 CMD echo "Built the DAS API bins!"

--- a/Ingest.Dockerfile
+++ b/Ingest.Dockerfile
@@ -1,5 +1,5 @@
 FROM das-api/builder AS files
-FROM rust:1.81-slim-bullseye
+FROM rust:1.82-slim-bullseye
 ARG APP=/usr/src/app
 RUN apt update \
     && apt install -y curl ca-certificates tzdata \

--- a/Load.Dockerfile
+++ b/Load.Dockerfile
@@ -1,5 +1,5 @@
 FROM das-api/builder AS files
-FROM rust:1.81-slim-bullseye
+FROM rust:1.82-slim-bullseye
 ARG APP=/usr/src/app
 RUN apt update \
     && apt install -y curl ca-certificates tzdata \

--- a/Migrator.Dockerfile
+++ b/Migrator.Dockerfile
@@ -1,6 +1,6 @@
 FROM das-api/builder AS files
 
-FROM rust:1.81-bullseye
+FROM rust:1.82-bullseye
 COPY init.sql /init.sql
 ENV INIT_FILE_PATH=/init.sql
 COPY --from=files /das/migration /bins/migration

--- a/Proxy.Dockerfile
+++ b/Proxy.Dockerfile
@@ -1,5 +1,5 @@
-FROM rust:1.81-bullseye AS builder
-RUN cargo install wasm-pack
+FROM rust:1.82-bullseye AS builder
+RUN cargo install wasm-pack --version 0.13.1
 
 RUN mkdir /rust
 COPY ./Cargo.toml /rust

--- a/metaplex-rpc-proxy/src/lib.rs
+++ b/metaplex-rpc-proxy/src/lib.rs
@@ -5,6 +5,10 @@ use proxy_wasm::types::*;
 use regex::{Regex, RegexBuilder};
 use std::time::Duration;
 
+// Workaround: forces wasm-bindgen to include required intrinsics for proxy-wasm build.
+#[allow(unused_imports)]
+use wasm_bindgen::JsValue;
+
 proxy_wasm::main! {{
     proxy_wasm::set_log_level(LogLevel::Trace);
     proxy_wasm::set_root_context(|_| -> Box<dyn RootContext> { Box::new(Root) });

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.82.0"
 components = ["clippy", "rustfmt"]
 targets = []
 profile = "minimal"

--- a/tools/txn_forwarder/src/lib.rs
+++ b/tools/txn_forwarder/src/lib.rs
@@ -26,6 +26,7 @@ use {
     tokio_stream::wrappers::LinesStream,
 };
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, thiserror::Error)]
 pub enum FindSignaturesError {
     #[error("Failed to fetch signatures: {0}")]


### PR DESCRIPTION
### Notes
~~* Remove unneeded crate metaplex-rpc-proxy.~~
* Fix metaplex-rpc-proxy by setting specific wasm-pack version and forcing wasm-bindgen to include required intrinsics
* Update Rust version in workspace and dockerfiles.

### Testing
* Docker build runs and load generator creates NFTs that are indexed.