### PR TITLE
Add `SpecificationAssetClass` and searchable `Interface` for BubblegumV2 assets.

### DIFF
--- a/Api.Dockerfile
+++ b/Api.Dockerfile
@@ -1,5 +1,5 @@
 FROM das-api/builder AS files
-FROM rust:1.81-slim-bullseye
+FROM rust:1.82-slim-bullseye
 ARG APP=/usr/src/app
 RUN apt update \
     && apt install -y curl ca-certificates tzdata \

--- a/Builder.Dockerfile
+++ b/Builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.81-bullseye AS builder
+FROM rust:1.82-bullseye AS builder
 RUN apt-get update -y && \
     apt-get install -y build-essential make git
     
@@ -21,6 +21,6 @@ WORKDIR /rust
 RUN --mount=type=cache,target=/rust/target,id=das-rust \
   cargo build --release --bins && cp `find /rust/target/release -maxdepth 1 -type f | sed 's/^\.\///' | grep -v "\." ` /rust/bins
     
-FROM rust:1.81-slim-bullseye as final
+FROM rust:1.82-slim-bullseye as final
 COPY --from=builder /rust/bins /das/
 CMD echo "Built the DAS API bins!"

--- a/Ingest.Dockerfile
+++ b/Ingest.Dockerfile
@@ -1,5 +1,5 @@
 FROM das-api/builder AS files
-FROM rust:1.81-slim-bullseye
+FROM rust:1.82-slim-bullseye
 ARG APP=/usr/src/app
 RUN apt update \
     && apt install -y curl ca-certificates tzdata \

--- a/Load.Dockerfile
+++ b/Load.Dockerfile
@@ -1,5 +1,5 @@
 FROM das-api/builder AS files
-FROM rust:1.81-slim-bullseye
+FROM rust:1.82-slim-bullseye
 ARG APP=/usr/src/app
 RUN apt update \
     && apt install -y curl ca-certificates tzdata \

--- a/Migrator.Dockerfile
+++ b/Migrator.Dockerfile
@@ -1,6 +1,6 @@
 FROM das-api/builder AS files
 
-FROM rust:1.81-bullseye
+FROM rust:1.82-bullseye
 COPY init.sql /init.sql
 ENV INIT_FILE_PATH=/init.sql
 COPY --from=files /das/migration /bins/migration

--- a/Proxy.Dockerfile
+++ b/Proxy.Dockerfile
@@ -1,5 +1,5 @@
-FROM rust:1.81-bullseye AS builder
-RUN cargo install wasm-pack
+FROM rust:1.82-bullseye AS builder
+RUN cargo install wasm-pack --version 0.13.1
 
 RUN mkdir /rust
 COPY ./Cargo.toml /rust

--- a/blockbuster/src/programs/bubblegum/mod.rs
+++ b/blockbuster/src/programs/bubblegum/mod.rs
@@ -16,7 +16,7 @@ use mpl_bubblegum::{
     types::{BubblegumEventType, MetadataArgs, UpdateArgs},
 };
 pub use mpl_bubblegum::{
-    types::{LeafSchema, UseMethod},
+    types::{LeafSchema, UseMethod, Version},
     InstructionName, LeafSchemaEvent, ID,
 };
 use solana_sdk::pubkey::Pubkey;

--- a/digital_asset_types/src/dao/generated/sea_orm_active_enums.rs
+++ b/digital_asset_types/src/dao/generated/sea_orm_active_enums.rs
@@ -4,34 +4,60 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "task_status")]
+pub enum TaskStatus {
+    #[sea_orm(string_value = "failed")]
+    Failed,
+    #[sea_orm(string_value = "pending")]
+    Pending,
+    #[sea_orm(string_value = "running")]
+    Running,
+    #[sea_orm(string_value = "success")]
+    Success,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "mutability")]
+pub enum Mutability {
+    #[sea_orm(string_value = "immutable")]
+    Immutable,
+    #[sea_orm(string_value = "mutable")]
+    Mutable,
+    #[sea_orm(string_value = "unknown")]
+    Unknown,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
 #[sea_orm(
     rs_type = "String",
     db_type = "Enum",
-    enum_name = "specification_asset_class"
+    enum_name = "specification_versions"
 )]
-pub enum SpecificationAssetClass {
-    #[sea_orm(string_value = "FUNGIBLE_ASSET")]
-    FungibleAsset,
-    #[sea_orm(string_value = "FUNGIBLE_TOKEN")]
-    FungibleToken,
-    #[sea_orm(string_value = "IDENTITY_NFT")]
-    IdentityNft,
-    #[sea_orm(string_value = "MPL_CORE_ASSET")]
-    MplCoreAsset,
-    #[sea_orm(string_value = "MPL_CORE_COLLECTION")]
-    MplCoreCollection,
-    #[sea_orm(string_value = "NFT")]
-    Nft,
-    #[sea_orm(string_value = "NON_TRANSFERABLE_NFT")]
-    NonTransferableNft,
-    #[sea_orm(string_value = "PRINT")]
-    Print,
-    #[sea_orm(string_value = "PRINTABLE_NFT")]
-    PrintableNft,
-    #[sea_orm(string_value = "PROGRAMMABLE_NFT")]
-    ProgrammableNft,
-    #[sea_orm(string_value = "TRANSFER_RESTRICTED_NFT")]
-    TransferRestrictedNft,
+pub enum SpecificationVersions {
+    #[sea_orm(string_value = "unknown")]
+    Unknown,
+    #[sea_orm(string_value = "v0")]
+    V0,
+    #[sea_orm(string_value = "v1")]
+    V1,
+    #[sea_orm(string_value = "v2")]
+    V2,
+}
+#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
+#[sea_orm(
+    rs_type = "String",
+    db_type = "Enum",
+    enum_name = "v1_account_attachments"
+)]
+pub enum V1AccountAttachments {
+    #[sea_orm(string_value = "edition")]
+    Edition,
+    #[sea_orm(string_value = "edition_marker")]
+    EditionMarker,
+    #[sea_orm(string_value = "master_edition_v1")]
+    MasterEditionV1,
+    #[sea_orm(string_value = "master_edition_v2")]
+    MasterEditionV2,
+    #[sea_orm(string_value = "token_inscription")]
+    TokenInscription,
     #[sea_orm(string_value = "unknown")]
     Unknown,
 }
@@ -52,30 +78,48 @@ pub enum RoyaltyTargetType {
     Unknown,
 }
 #[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "owner_type")]
-pub enum OwnerType {
-    #[sea_orm(string_value = "single")]
-    Single,
-    #[sea_orm(string_value = "token")]
-    Token,
+#[sea_orm(
+    rs_type = "String",
+    db_type = "Enum",
+    enum_name = "specification_asset_class"
+)]
+pub enum SpecificationAssetClass {
+    #[sea_orm(string_value = "FUNGIBLE_ASSET")]
+    FungibleAsset,
+    #[sea_orm(string_value = "FUNGIBLE_TOKEN")]
+    FungibleToken,
+    #[sea_orm(string_value = "IDENTITY_NFT")]
+    IdentityNft,
+    #[sea_orm(string_value = "MPL_BUBBLEGUM_V2")]
+    MplBubblegumV2,
+    #[sea_orm(string_value = "MPL_CORE_ASSET")]
+    MplCoreAsset,
+    #[sea_orm(string_value = "MPL_CORE_COLLECTION")]
+    MplCoreCollection,
+    #[sea_orm(string_value = "NFT")]
+    Nft,
+    #[sea_orm(string_value = "NON_TRANSFERABLE_NFT")]
+    NonTransferableNft,
+    #[sea_orm(string_value = "PRINT")]
+    Print,
+    #[sea_orm(string_value = "PRINTABLE_NFT")]
+    PrintableNft,
+    #[sea_orm(string_value = "PROGRAMMABLE_NFT")]
+    ProgrammableNft,
+    #[sea_orm(string_value = "TRANSFER_RESTRICTED_NFT")]
+    TransferRestrictedNft,
     #[sea_orm(string_value = "unknown")]
     Unknown,
 }
 #[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(
-    rs_type = "String",
-    db_type = "Enum",
-    enum_name = "specification_versions"
-)]
-pub enum SpecificationVersions {
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "chain_mutability")]
+pub enum ChainMutability {
+    #[sea_orm(string_value = "immutable")]
+    Immutable,
+    #[sea_orm(string_value = "mutable")]
+    Mutable,
     #[sea_orm(string_value = "unknown")]
     Unknown,
-    #[sea_orm(string_value = "v0")]
-    V0,
-    #[sea_orm(string_value = "v1")]
-    V1,
-    #[sea_orm(string_value = "v2")]
-    V2,
 }
 #[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "instruction")]
@@ -142,54 +186,12 @@ pub enum Instruction {
     VerifyCreatorV2,
 }
 #[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "mutability")]
-pub enum Mutability {
-    #[sea_orm(string_value = "immutable")]
-    Immutable,
-    #[sea_orm(string_value = "mutable")]
-    Mutable,
-    #[sea_orm(string_value = "unknown")]
-    Unknown,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "task_status")]
-pub enum TaskStatus {
-    #[sea_orm(string_value = "failed")]
-    Failed,
-    #[sea_orm(string_value = "pending")]
-    Pending,
-    #[sea_orm(string_value = "running")]
-    Running,
-    #[sea_orm(string_value = "success")]
-    Success,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(
-    rs_type = "String",
-    db_type = "Enum",
-    enum_name = "v1_account_attachments"
-)]
-pub enum V1AccountAttachments {
-    #[sea_orm(string_value = "edition")]
-    Edition,
-    #[sea_orm(string_value = "edition_marker")]
-    EditionMarker,
-    #[sea_orm(string_value = "master_edition_v1")]
-    MasterEditionV1,
-    #[sea_orm(string_value = "master_edition_v2")]
-    MasterEditionV2,
-    #[sea_orm(string_value = "token_inscription")]
-    TokenInscription,
-    #[sea_orm(string_value = "unknown")]
-    Unknown,
-}
-#[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "chain_mutability")]
-pub enum ChainMutability {
-    #[sea_orm(string_value = "immutable")]
-    Immutable,
-    #[sea_orm(string_value = "mutable")]
-    Mutable,
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "owner_type")]
+pub enum OwnerType {
+    #[sea_orm(string_value = "single")]
+    Single,
+    #[sea_orm(string_value = "token")]
+    Token,
     #[sea_orm(string_value = "unknown")]
     Unknown,
 }

--- a/digital_asset_types/src/dapi/common/asset.rs
+++ b/digital_asset_types/src/dapi/common/asset.rs
@@ -211,7 +211,8 @@ pub fn v1_content_from_json(asset_data: &asset_data::Model) -> Result<Content, D
             links.insert(f.to_string(), l.to_owned());
         }
     }
-    let _metadata = safe_select(selector, "description");
+    let category = safe_select(selector, "$.properties.category").cloned();
+
     let mut actual_files: HashMap<String, File> = HashMap::new();
     if let Some(files) = selector("$.properties.files[*]")
         .ok()
@@ -280,6 +281,7 @@ pub fn v1_content_from_json(asset_data: &asset_data::Model) -> Result<Content, D
         files: Some(files),
         metadata: meta,
         links: Some(links),
+        category,
     })
 }
 

--- a/digital_asset_types/src/rpc/asset.rs
+++ b/digital_asset_types/src/rpc/asset.rs
@@ -47,6 +47,8 @@ pub enum Interface {
     MplCoreAsset,
     #[serde(rename = "MplCoreCollection")]
     MplCoreCollection,
+    #[serde(rename = "MplBubblegumV2")]
+    MplBubblegumV2,
     #[default]
     #[serde(rename = "Custom")]
     Custom,
@@ -55,20 +57,21 @@ pub enum Interface {
 impl From<(Option<&SpecificationVersions>, &SpecificationAssetClass)> for Interface {
     fn from(i: (Option<&SpecificationVersions>, &SpecificationAssetClass)) -> Self {
         match i {
+            (_, SpecificationAssetClass::FungibleAsset) => Interface::FungibleAsset,
+            (_, SpecificationAssetClass::FungibleToken) => Interface::FungibleToken,
+            (_, SpecificationAssetClass::MplBubblegumV2) => Interface::MplBubblegumV2,
+            (_, SpecificationAssetClass::MplCoreAsset) => Interface::MplCoreAsset,
+            (_, SpecificationAssetClass::MplCoreCollection) => Interface::MplCoreCollection,
+            (Some(SpecificationVersions::V0), SpecificationAssetClass::Nft) => {
+                Interface::LEGACY_NFT
+            }
             (Some(SpecificationVersions::V1), SpecificationAssetClass::Nft) => Interface::V1NFT,
             (Some(SpecificationVersions::V1), SpecificationAssetClass::PrintableNft) => {
                 Interface::V1NFT
             }
-            (Some(SpecificationVersions::V0), SpecificationAssetClass::Nft) => {
-                Interface::LEGACY_NFT
-            }
             (Some(SpecificationVersions::V1), SpecificationAssetClass::ProgrammableNft) => {
                 Interface::ProgrammableNFT
             }
-            (_, SpecificationAssetClass::MplCoreAsset) => Interface::MplCoreAsset,
-            (_, SpecificationAssetClass::MplCoreCollection) => Interface::MplCoreCollection,
-            (_, SpecificationAssetClass::FungibleAsset) => Interface::FungibleAsset,
-            (_, SpecificationAssetClass::FungibleToken) => Interface::FungibleToken,
             _ => Interface::Custom,
         }
     }
@@ -78,15 +81,19 @@ impl From<Interface> for (SpecificationVersions, SpecificationAssetClass) {
     fn from(interface: Interface) -> (SpecificationVersions, SpecificationAssetClass) {
         match interface {
             Interface::V1NFT => (SpecificationVersions::V1, SpecificationAssetClass::Nft),
-            Interface::LEGACY_NFT => (SpecificationVersions::V0, SpecificationAssetClass::Nft),
-            Interface::ProgrammableNFT => (
-                SpecificationVersions::V1,
-                SpecificationAssetClass::ProgrammableNft,
-            ),
             Interface::V1PRINT => (SpecificationVersions::V1, SpecificationAssetClass::Print),
+            Interface::LEGACY_NFT => (SpecificationVersions::V0, SpecificationAssetClass::Nft),
             Interface::FungibleAsset => (
                 SpecificationVersions::V1,
                 SpecificationAssetClass::FungibleAsset,
+            ),
+            Interface::FungibleToken => (
+                SpecificationVersions::V1,
+                SpecificationAssetClass::FungibleToken,
+            ),
+            Interface::ProgrammableNFT => (
+                SpecificationVersions::V1,
+                SpecificationAssetClass::ProgrammableNft,
             ),
             Interface::MplCoreAsset => (
                 SpecificationVersions::V1,
@@ -96,9 +103,9 @@ impl From<Interface> for (SpecificationVersions, SpecificationAssetClass) {
                 SpecificationVersions::V1,
                 SpecificationAssetClass::MplCoreCollection,
             ),
-            Interface::FungibleToken => (
+            Interface::MplBubblegumV2 => (
                 SpecificationVersions::V1,
-                SpecificationAssetClass::FungibleToken,
+                SpecificationAssetClass::MplBubblegumV2,
             ),
             _ => (SpecificationVersions::V1, SpecificationAssetClass::Unknown),
         }

--- a/digital_asset_types/src/rpc/asset.rs
+++ b/digital_asset_types/src/rpc/asset.rs
@@ -180,6 +180,8 @@ pub struct Content {
     pub metadata: MetadataMap,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<Links>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub category: Option<Value>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__add_asset_to_collection_using_set_collection_v2.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__add_asset_to_collection_using_set_collection_v2.snap
@@ -4,7 +4,7 @@ assertion_line: 33
 expression: response
 ---
 {
-  "interface": "V1_NFT",
+  "interface": "MplBubblegumV2",
   "id": "5fADezYRRBaiLcRrSMC5Wsqj4mpd4BJkJvjTTQBWaB5T",
   "content": {
     "$schema": "https://schema.metaplex.com/nft1.0.json",

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__change_collection_using_set_collection_v2.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__change_collection_using_set_collection_v2.snap
@@ -4,7 +4,7 @@ assertion_line: 33
 expression: response
 ---
 {
-  "interface": "V1_NFT",
+  "interface": "MplBubblegumV2",
   "id": "7xNZ8rh4zH9EoACqEWymt5FSwgjbkDM1uFQ6MSB6kwc8",
   "content": {
     "$schema": "https://schema.metaplex.com/nft1.0.json",

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__delegate_and_freeze_v2.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__delegate_and_freeze_v2.snap
@@ -4,7 +4,7 @@ assertion_line: 33
 expression: response
 ---
 {
-  "interface": "V1_NFT",
+  "interface": "MplBubblegumV2",
   "id": "5ryKjZ554B9aSKWyEH4kprdjQSvRk3ioAVPgsxRqcDAf",
   "content": {
     "$schema": "https://schema.metaplex.com/nft1.0.json",

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__delegate_v2.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__delegate_v2.snap
@@ -4,7 +4,7 @@ assertion_line: 33
 expression: response
 ---
 {
-  "interface": "V1_NFT",
+  "interface": "MplBubblegumV2",
   "id": "6F3Dv73qYxay78WtGMqjB4voY7E8GSmYvbq8nDNroAeC",
   "content": {
     "$schema": "https://schema.metaplex.com/nft1.0.json",

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__freeze_v2.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__freeze_v2.snap
@@ -4,7 +4,7 @@ assertion_line: 33
 expression: response
 ---
 {
-  "interface": "V1_NFT",
+  "interface": "MplBubblegumV2",
   "id": "4ynkSgr8S9pq3a2ynNHVfJbAcBrBxJUFkRCkwmjEc3TS",
   "content": {
     "$schema": "https://schema.metaplex.com/nft1.0.json",

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__freeze_v2_using_permanent_delegate.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__freeze_v2_using_permanent_delegate.snap
@@ -4,7 +4,7 @@ assertion_line: 33
 expression: response
 ---
 {
-  "interface": "V1_NFT",
+  "interface": "MplBubblegumV2",
   "id": "9j8QfKwJvzjiHwcRyi1TCK7sZgm8iEBpGn8sRyGF5Wy8",
   "content": {
     "$schema": "https://schema.metaplex.com/nft1.0.json",

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__mint_v2_not_to_collection.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__mint_v2_not_to_collection.snap
@@ -4,7 +4,7 @@ assertion_line: 33
 expression: response
 ---
 {
-  "interface": "V1_NFT",
+  "interface": "MplBubblegumV2",
   "id": "8FD8ZTQtPzPzADnSUs1sb3vb54MxQ29mJkcEDTGzDANA",
   "content": {
     "$schema": "https://schema.metaplex.com/nft1.0.json",

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__mint_v2_to_collection_burn_v2.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__mint_v2_to_collection_burn_v2.snap
@@ -4,7 +4,7 @@ assertion_line: 33
 expression: response
 ---
 {
-  "interface": "V1_NFT",
+  "interface": "MplBubblegumV2",
   "id": "FJDXSjkTpx7zZm3mcxzFzHPJ4EMLzgU9DaMtMvHPY6em",
   "content": {
     "$schema": "https://schema.metaplex.com/nft1.0.json",

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__mint_v2_to_collection_only.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__mint_v2_to_collection_only.snap
@@ -4,7 +4,7 @@ assertion_line: 33
 expression: response
 ---
 {
-  "interface": "V1_NFT",
+  "interface": "MplBubblegumV2",
   "id": "HGu4vJMLCboGNNVnH6UXrQZKVVXBX4xMZFxfmFgQD9pG",
   "content": {
     "$schema": "https://schema.metaplex.com/nft1.0.json",

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__mint_v2_to_collection_transfer_v2.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__mint_v2_to_collection_transfer_v2.snap
@@ -4,7 +4,7 @@ assertion_line: 33
 expression: response
 ---
 {
-  "interface": "V1_NFT",
+  "interface": "MplBubblegumV2",
   "id": "86c2p9hZJTPWmFRKz1znX3yx9E8vhESk9wr9soTMET8Y",
   "content": {
     "$schema": "https://schema.metaplex.com/nft1.0.json",

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__mint_v2_transfer_v2.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__mint_v2_transfer_v2.snap
@@ -4,7 +4,7 @@ assertion_line: 33
 expression: response
 ---
 {
-  "interface": "V1_NFT",
+  "interface": "MplBubblegumV2",
   "id": "H98ZTBg5XdWRxt35XDznbX2Z1m7nCYeYqoBTdi5qAQBg",
   "content": {
     "$schema": "https://schema.metaplex.com/nft1.0.json",

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__remove_from_collection_using_set_collection_v2.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__remove_from_collection_using_set_collection_v2.snap
@@ -4,7 +4,7 @@ assertion_line: 33
 expression: response
 ---
 {
-  "interface": "V1_NFT",
+  "interface": "MplBubblegumV2",
   "id": "HN6V2risGpYADNKyRoceBwgrUJDnSm6h21uSTLbLVaPY",
   "content": {
     "$schema": "https://schema.metaplex.com/nft1.0.json",

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__set_non_transferable_v2.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__set_non_transferable_v2.snap
@@ -4,7 +4,7 @@ assertion_line: 33
 expression: response
 ---
 {
-  "interface": "V1_NFT",
+  "interface": "MplBubblegumV2",
   "id": "9JZWk34GEsxNWRF6XRxL6LYDhs5W7AuUVX2VHo9UV7ds",
   "content": {
     "$schema": "https://schema.metaplex.com/nft1.0.json",

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__thaw_and_revoke_v2.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__thaw_and_revoke_v2.snap
@@ -4,7 +4,7 @@ assertion_line: 33
 expression: response
 ---
 {
-  "interface": "V1_NFT",
+  "interface": "MplBubblegumV2",
   "id": "J1iH8MiPeW6rFZP8hjM8PEXFAwaKpcHyb5mgsB1pji5r",
   "content": {
     "$schema": "https://schema.metaplex.com/nft1.0.json",

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__unverify_creator_v2.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__unverify_creator_v2.snap
@@ -4,7 +4,7 @@ assertion_line: 33
 expression: response
 ---
 {
-  "interface": "V1_NFT",
+  "interface": "MplBubblegumV2",
   "id": "Eoz1EtUHHpNPXU8UHM5dP93npGWzLx6uh19ExexhMwBm",
   "content": {
     "$schema": "https://schema.metaplex.com/nft1.0.json",

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__update_metadata_v2_new_name_new_uri.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__update_metadata_v2_new_name_new_uri.snap
@@ -4,7 +4,7 @@ assertion_line: 33
 expression: response
 ---
 {
-  "interface": "V1_NFT",
+  "interface": "MplBubblegumV2",
   "id": "38pabFkaBAVUBwPotd1Wync8ECDbVe8iZLxJyDgZG8jo",
   "content": {
     "$schema": "https://schema.metaplex.com/nft1.0.json",

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__verify_creator_v2.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__cnft_tests_v2_leaf_schema__verify_creator_v2.snap
@@ -4,7 +4,7 @@ assertion_line: 33
 expression: response
 ---
 {
-  "interface": "V1_NFT",
+  "interface": "MplBubblegumV2",
   "id": "7zKon1FrkcHr8cQnEmch9fWn6mfNgihxQz7kqqTVtDE2",
   "content": {
     "$schema": "https://schema.metaplex.com/nft1.0.json",

--- a/metaplex-rpc-proxy/src/lib.rs
+++ b/metaplex-rpc-proxy/src/lib.rs
@@ -5,6 +5,10 @@ use proxy_wasm::types::*;
 use regex::{Regex, RegexBuilder};
 use std::time::Duration;
 
+// Workaround: forces wasm-bindgen to include required intrinsics for proxy-wasm build.
+#[allow(unused_imports)]
+use wasm_bindgen::JsValue;
+
 proxy_wasm::main! {{
     proxy_wasm::set_log_level(LogLevel::Trace);
     proxy_wasm::set_root_context(|_| -> Box<dyn RootContext> { Box::new(Root) });

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -50,6 +50,7 @@ mod m20250313_105132_drop_idx_token_accounts_owner_and_idx_ta_mint;
 mod m20250313_105206_add_idx_ta_owner_amount_and_idx_ta_mint_amount;
 mod m20250321_120101_add_bgum_leaf_schema_v2_items;
 mod m20250327_120101_add_bubblegum_v2_ixs_to_enum;
+mod m20250702_120101_add_bubblegum_v2_enum_vals;
 
 pub mod model;
 
@@ -109,6 +110,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20250313_105206_add_idx_ta_owner_amount_and_idx_ta_mint_amount::Migration),
             Box::new(m20250321_120101_add_bgum_leaf_schema_v2_items::Migration),
             Box::new(m20250327_120101_add_bubblegum_v2_ixs_to_enum::Migration),
+            Box::new(m20250702_120101_add_bubblegum_v2_enum_vals::Migration),
         ]
     }
 }

--- a/migration/src/m20250702_120101_add_bubblegum_v2_enum_vals.rs
+++ b/migration/src/m20250702_120101_add_bubblegum_v2_enum_vals.rs
@@ -1,0 +1,27 @@
+use sea_orm_migration::{
+    prelude::*,
+    sea_orm::{ConnectionTrait, DatabaseBackend, Statement},
+};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute(Statement::from_string(
+                DatabaseBackend::Postgres,
+                "ALTER TYPE specification_asset_class ADD VALUE IF NOT EXISTS 'MPL_BUBBLEGUM_V2';"
+                    .to_string(),
+            ))
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        Ok(())
+    }
+}

--- a/program_transformers/src/bubblegum/mint.rs
+++ b/program_transformers/src/bubblegum/mint.rs
@@ -15,7 +15,7 @@ use {
     },
     blockbuster::{
         instruction::InstructionBundle,
-        programs::bubblegum::{BubblegumInstruction, Payload},
+        programs::bubblegum::{BubblegumInstruction, Payload, Version},
         token_metadata::types::{TokenStandard, Uses},
     },
     digital_asset_types::{
@@ -109,13 +109,20 @@ where
             Some(leaf.delegate.to_bytes().to_vec())
         };
 
+        // BubblegumV2 now gets its own `SpecificationAssetClass` and `Interface`.
+        let specification_asset_class = if matches!(le.version, Version::V2) {
+            SpecificationAssetClass::MplBubblegumV2
+        } else {
+            SpecificationAssetClass::Nft
+        };
+
         // Upsert `asset` table base info and `asset_creators` table.
         upsert_asset_base_info(
             &multi_txn,
             id_bytes.to_vec(),
             OwnerType::Single,
             SpecificationVersions::V1,
-            SpecificationAssetClass::Nft,
+            specification_asset_class,
             RoyaltyTargetType::Creators,
             None,
             metadata.seller_fee_basis_points as i32,

--- a/program_transformers/src/bubblegum/update_metadata.rs
+++ b/program_transformers/src/bubblegum/update_metadata.rs
@@ -13,7 +13,7 @@ use {
     },
     blockbuster::{
         instruction::InstructionBundle,
-        programs::bubblegum::{BubblegumInstruction, Payload},
+        programs::bubblegum::{BubblegumInstruction, Payload, Version},
         token_metadata::types::{TokenStandard, Uses},
     },
     digital_asset_types::{
@@ -144,12 +144,19 @@ where
             &current_metadata.creators
         };
 
+        // BubblegumV2 now gets its own `SpecificationAssetClass` and `Interface`.
+        let specification_asset_class = if matches!(le.version, Version::V2) {
+            SpecificationAssetClass::MplBubblegumV2
+        } else {
+            SpecificationAssetClass::Nft
+        };
+
         upsert_asset_base_info(
             &multi_txn,
             id_bytes.to_vec(),
             OwnerType::Single,
             SpecificationVersions::V1,
-            SpecificationAssetClass::Nft,
+            specification_asset_class,
             RoyaltyTargetType::Creators,
             None,
             seller_fee_basis_points as i32,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.82.0"
 components = ["clippy", "rustfmt"]
 targets = []
 profile = "minimal"

--- a/tools/txn_forwarder/src/lib.rs
+++ b/tools/txn_forwarder/src/lib.rs
@@ -26,6 +26,7 @@ use {
     tokio_stream::wrappers::LinesStream,
 };
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, thiserror::Error)]
 pub enum FindSignaturesError {
     #[error("Failed to fetch signatures: {0}")]


### PR DESCRIPTION
### Notes
* Request from DevRel/community to help tell the difference between BubblegumV1 and BubblegumV2 assets and allow for finding only V2 assets using `searchAssets`.
* Doesn't store any additional data, but includes a database migration to add a new SeaORM `ActiveEnum` value.
* Indexes new BubblegumV2 assets with the new SpecificationAssetClass.
* Existing BubblegumV2 assets will still return the new interface as it can be inferred at the time of RPC query.

### Testing
* Integration test results updated and pass.